### PR TITLE
fix: correct mappedBy/inversedBy usage and RelationColumn behavior

### DIFF
--- a/packages/objectquel/src/Annotations/Orm/ManyToOne.php
+++ b/packages/objectquel/src/Annotations/Orm/ManyToOne.php
@@ -47,20 +47,10 @@
 		/**
 		 * Retrieve the name of the relationship column.
 		 * This method retrieves the name of the column that represents the ManyToOne relationship in the database.
-		 * The column name is determined based on the following priorities:
-		 * 1. If the parameter "relationColumn" is set in the annotation, then this value is used.
-		 * 2. If "relationColumn" is not set but "inversedBy" is, then the value of "inversedBy" is used.
-		 * 3. If neither parameter is set, null is returned.
 		 * @return string|null The name of the join column or null if it is not set.
 		 */
 		public function getRelationColumn(): ?string {
-			if (isset($this->parameters["relationColumn"])) {
-				return $this->parameters["relationColumn"];
-			} elseif (isset($this->parameters["inversedBy"])) {
-				return $this->parameters["inversedBy"];
-			} else {
-				return null;
-			}
+			return $this->parameters["relationColumn"] ?? null;
 		}
 		
 		/**

--- a/packages/objectquel/src/Annotations/Orm/OneToMany.php
+++ b/packages/objectquel/src/Annotations/Orm/OneToMany.php
@@ -51,10 +51,6 @@
 		/**
 		 * Retrieve the name of the relationship column.
 		 * This method retrieves the name of the column that represents the OneToMany relationship in the database.
-		 * The column name is determined based on the following priorities:
-		 * 1. If the parameter "relationColumn" is set in the annotation, then this value is used.
-		 * 2. If "relationColumn" is not set but "mappedBy" is, then the value of "mappedBy" is used.
-		 * 3. If neither parameter is set, null is returned.
 		 * @return string|null The name of the join column or null if it is not set.
 		 */
 		public function getRelationColumn(): ?string {

--- a/packages/objectquel/src/Annotations/Orm/OneToOne.php
+++ b/packages/objectquel/src/Annotations/Orm/OneToOne.php
@@ -55,18 +55,10 @@
 		/**
 		 * Retrieves the name of the relationship column.
 		 * This method retrieves the name of the column that represents the ManyToOne relationship in the database.
-		 * The column name is determined based on the following priorities:
-		 * 1. If the parameter "relationColumn" is set in the annotation, then this value is used.
-		 * 2. If "relationColumn" is not set but "inversedBy" is, then the value of "inversedBy" is used.
-		 * 3. If neither parameter is set, null is returned.
 		 * @return string|null The name of the join column or null if it is not set.
 		 */
 		public function getRelationColumn(): ?string {
-			if (!isset($this->parameters["relationColumn"])) {
-				return null;
-			}
-			
-			return $this->parameters["relationColumn"];
+			return $this->parameters["relationColumn"] ?? null;
 		}
 		
 		/**

--- a/packages/objectquel/src/EntityStore.php
+++ b/packages/objectquel/src/EntityStore.php
@@ -719,12 +719,12 @@
 	     */
 	    private function internalGetDependencies(mixed $entity, string $desiredAnnotationType): array {
 		    // Determine the class name of the entity
-		    if (!is_object($entity)) {
-			    $entityClass = ltrim($entity, "\\");
-		    } elseif ($entity instanceof \ReflectionClass) {
+		    if ($entity instanceof \ReflectionClass) {
 			    $entityClass = $entity->getName();
-		    } else {
+		    } elseif (is_object($entity)) {
 			    $entityClass = get_class($entity);
+		    } else {
+			    $entityClass = ltrim($entity, "\\");
 		    }
 		    
 		    // If the class name is a proxy, get the class from the parent

--- a/packages/objectquel/src/QueryManagement/QueryExecutor.php
+++ b/packages/objectquel/src/QueryManagement/QueryExecutor.php
@@ -106,66 +106,6 @@
 		}
 		
 		/**
-		 * Retrieves all results of an executed ObjectQuel query.
-		 * @param string $query
-		 * @param array $parameters
-		 * @return array
-		 * @throws QuelException
-		 */
-		public function getAll(string $query, array $parameters = []): array {
-			// Executes the query with the specified parameters.
-			$rs = $this->executeQuery($query, $parameters);
-			
-			// Checks if the query has successful results.
-			if ($rs->recordCount() == 0) {
-				return [];
-			}
-			
-			// Iterates through all rows of the result.
-			$result = [];
-			while ($row = $rs->fetchRow()) {
-				$result[] = $row;
-			}
-			
-			return $result;
-		}
-		
-		/**
-		 * Executes an ObjectQuel query and returns an array of objects from the
-		 * first column of each result, with duplicates removed.
-		 * @param string $query The ObjectQuel query to execute.
-		 * @param array $parameters Optional parameters for the query.
-		 * @return array An array of unique objects from the first column of the query results.
-		 * @throws QuelException
-		 */
-		public function getCol(string $query, array $parameters = []): array {
-			// Executes the query with the specified parameters.
-			$rs = $this->executeQuery($query, $parameters);
-			
-			// Checks if the query was successful and has results.
-			if ($rs->recordCount() == 0) {
-				return [];
-			}
-			
-			// Get the result
-			$result = [];
-			$keys = null;
-			
-			while ($row = $rs->fetchRow()) {
-				// Determines the keys (column names) of the first row, if not already determined.
-				if ($keys === null) {
-					$keys = array_keys($row);
-				}
-				
-				// Adds the value of the first column to the result.
-				$result[] = $row[$keys[0]];
-			}
-			
-			// Returns deduplicated results.
-			return $this->deDuplicateObjects($result);
-		}
-		
-		/**
 		 * Execute a decomposed query plan
 		 * @param string $query The query to execute
 		 * @param array $parameters Initial parameters for the plan

--- a/versioning/versions.json
+++ b/versioning/versions.json
@@ -3,7 +3,7 @@
   "discover": "1.0.20",
   "dependency-injection": "1.0.21",
   "sculpt": "1.0.20",
-  "objectquel": "1.0.21",
+  "objectquel": "1.0.22",
   "signal-hub": "1.0.21",
   "annotation-reader": "1.0.21",
   "canvas": "1.0.30",


### PR DESCRIPTION
- Fix mappedBy and inversedBy to reference the other side of relations, not primary keys
- Update RelationColumn to use {propertyName}Id naming convention instead of defaulting to inversedBy
- Align relationship mapping with proper ORM conventions