### PR TITLE
Fix EntityLocator silently dropping entities via docblock false-match

### DIFF
--- a/packages/objectquel/src/ReflectionManagement/EntityLocator.php
+++ b/packages/objectquel/src/ReflectionManagement/EntityLocator.php
@@ -115,42 +115,118 @@
 		}
 		
 		/**
-		 * Extracts the fully qualified class name from a PHP file by reading its content
+		 * Extracts the fully qualified class name from a PHP file by tokenizing its content.
+		 * Uses PHP's own tokenizer (rather than a regex over the raw source) so that
+		 * the word "class" appearing inside a docblock or comment can never be
+		 * mistaken for the actual class declaration.
 		 * @param string $filePath The full path to the PHP file
 		 * @return string|null The fully qualified class name, or null if not found
 		 */
 		private function extractEntityNameFromFile(string $filePath): ?string {
 			// Read the file contents
 			$contents = file_get_contents($filePath);
-			
+
 			// If no content found, return null
 			if ($contents === false) {
 				return null;
 			}
-			
-			// Extract the namespace
-			if (preg_match('/namespace\s+([^;]+);/s', $contents, $namespaceMatches)) {
-				$namespace = $namespaceMatches[1];
-			} else {
-				$namespace = '';
+
+			// Tokenize the source. Comments/docblocks become T_COMMENT/T_DOC_COMMENT
+			// tokens, so their text can never be picked up as a namespace or class name.
+			$tokens = token_get_all($contents);
+			$tokenCount = count($tokens);
+			$namespace = '';
+			$className = null;
+
+			for ($i = 0; $i < $tokenCount; $i++) {
+				$token = $tokens[$i];
+
+				if (!is_array($token)) {
+					continue;
+				}
+
+				$id = $token[0];
+
+				// Namespace declaration: concatenate every non-whitespace token
+				// until the terminating ';' or '{'
+				if ($id === T_NAMESPACE) {
+					$namespace = '';
+
+					for ($j = $i + 1; $j < $tokenCount; $j++) {
+						$next = $tokens[$j];
+
+						if ($next === ';' || $next === '{') {
+							break;
+						}
+
+						if (is_array($next) && $next[0] !== T_WHITESPACE) {
+							$namespace .= $next[1];
+						}
+					}
+
+					continue;
+				}
+
+				// Class declaration: take the identifier that immediately follows
+				// the "class" keyword, but skip `Foo::class` and `new class { ... }`
+				if ($id === T_CLASS && $className === null) {
+					$previous = $this->previousNonWhitespaceToken($tokens, $i);
+
+					if (
+						is_array($previous) &&
+						in_array($previous[0], [T_DOUBLE_COLON, T_NEW], true)
+					) {
+						continue;
+					}
+
+					for ($j = $i + 1; $j < $tokenCount; $j++) {
+						$next = $tokens[$j];
+
+						if (is_array($next) && $next[0] === T_WHITESPACE) {
+							continue;
+						}
+
+						if (is_array($next) && $next[0] === T_STRING) {
+							$className = $next[1];
+						}
+
+						break;
+					}
+				}
 			}
-			
-			// Extract the class name
-			if (preg_match('/class\s+(\w+)/s', $contents, $classMatches)) {
-				$className = $classMatches[1];
+
+			if ($className !== null) {
 				return $namespace . '\\' . $className;
 			}
-			
+
 			// If no class found, use filename as class name (without .php extension)
 			$fileName = basename($filePath);
 			$pos = strpos($fileName, '.php');
-			
+
 			if ($pos === false) {
 				return $namespace . '\\' . $fileName;
 			}
-			
+
 			$className = substr($fileName, 0, $pos);
 			return $namespace . '\\' . $className;
+		}
+
+		/**
+		 * Returns the nearest preceding token that isn't whitespace
+		 * @param array $tokens Full token list from token_get_all()
+		 * @param int $index Index to search backwards from (exclusive)
+		 * @return array|string|null
+		 */
+		private function previousNonWhitespaceToken(array $tokens, int $index) {
+			for ($i = $index - 1; $i >= 0; $i--) {
+				if (is_array($tokens[$i]) && $tokens[$i][0] === T_WHITESPACE) {
+					continue;
+				}
+
+				return $tokens[$i];
+			}
+
+			return null;
 		}
 		
 		/**

--- a/packages/objectquel/src/ReflectionManagement/EntityLocator.php
+++ b/packages/objectquel/src/ReflectionManagement/EntityLocator.php
@@ -213,11 +213,11 @@
 
 		/**
 		 * Returns the nearest preceding token that isn't whitespace
-		 * @param array $tokens Full token list from token_get_all()
+		 * @param list<array{0: int, 1: string, 2: int}|string> $tokens Full token list from token_get_all()
 		 * @param int $index Index to search backwards from (exclusive)
-		 * @return array|string|null
+		 * @return array{0: int, 1: string, 2: int}|string|null
 		 */
-		private function previousNonWhitespaceToken(array $tokens, int $index) {
+		private function previousNonWhitespaceToken(array $tokens, int $index): array|string|null {
 			for ($i = $index - 1; $i >= 0; $i--) {
 				if (is_array($tokens[$i]) && $tokens[$i][0] === T_WHITESPACE) {
 					continue;

--- a/tests/ObjectQuel/EntityLocatorTest.php
+++ b/tests/ObjectQuel/EntityLocatorTest.php
@@ -1,0 +1,128 @@
+<?php
+
+	declare(strict_types=1);
+
+	namespace Quellabs\ObjectQuel\Tests;
+
+	use PHPUnit\Framework\TestCase;
+	use Quellabs\ObjectQuel\ReflectionManagement\EntityLocator;
+	use ReflectionClass;
+
+	/**
+	 * Unit tests for EntityLocator::extractEntityNameFromFile().
+	 *
+	 * Regression coverage for a bug where the class name was extracted with a
+	 * regex over the raw file contents. A class-level docblock containing the
+	 * literal sequence "class" + whitespace + word (e.g. "one query class from
+	 * a log") matched before the real `class Foo {` declaration, so the wrong
+	 * name was extracted and the entity was silently dropped from discovery.
+	 */
+	class EntityLocatorTest extends TestCase {
+
+		private array $tempFiles = [];
+
+		protected function tearDown(): void {
+			foreach ($this->tempFiles as $file) {
+				if (is_file($file)) {
+					unlink($file);
+				}
+			}
+
+			$this->tempFiles = [];
+		}
+
+		/**
+		 * Writes $contents to a temp .php file and returns the extracted FQCN.
+		 */
+		private function extract(string $contents): ?string {
+			$file = tempnam(sys_get_temp_dir(), 'el_test_') . '.php';
+			file_put_contents($file, $contents);
+			$this->tempFiles[] = $file;
+
+			$locator = (new ReflectionClass(EntityLocator::class))->newInstanceWithoutConstructor();
+			$method = new \ReflectionMethod(EntityLocator::class, 'extractEntityNameFromFile');
+			$method->setAccessible(true);
+
+			return $method->invoke($locator, $file);
+		}
+
+		public function testDocblockContainingClassWordDoesNotShadowRealDeclaration(): void {
+			$contents = <<<'PHP'
+<?php
+
+namespace App\Entities;
+
+/**
+ * This entity represents one query class from a processed log.
+ * It's also used when importing a class into the monitoring pipeline.
+ */
+class SlowLogQueryClassEntity {
+	private int $id;
+}
+PHP;
+
+			$this->assertSame(
+				'App\\Entities\\SlowLogQueryClassEntity',
+				$this->extract($contents)
+			);
+		}
+
+		public function testPlainClassDeclarationIsExtracted(): void {
+			$contents = <<<'PHP'
+<?php
+
+namespace App\Entities;
+
+class PlainEntity {
+	private int $id;
+}
+PHP;
+
+			$this->assertSame(
+				'App\\Entities\\PlainEntity',
+				$this->extract($contents)
+			);
+		}
+
+		public function testClassConstantReferenceBeforeDeclarationIsIgnored(): void {
+			$contents = <<<'PHP'
+<?php
+
+namespace App\Entities;
+
+use Some\Other\Thing;
+
+$defaultFqcn = Thing::class;
+
+class RealEntity {
+	private $x = Thing::class;
+}
+PHP;
+
+			$this->assertSame(
+				'App\\Entities\\RealEntity',
+				$this->extract($contents)
+			);
+		}
+
+		public function testAnonymousClassBeforeDeclarationIsIgnored(): void {
+			$contents = <<<'PHP'
+<?php
+
+namespace App\Entities;
+
+$anon = new class {
+	public $y = 1;
+};
+
+class RealEntity {
+	private int $id;
+}
+PHP;
+
+			$this->assertSame(
+				'App\\Entities\\RealEntity',
+				$this->extract($contents)
+			);
+		}
+	}

--- a/versioning/versions.json
+++ b/versioning/versions.json
@@ -37,7 +37,7 @@
   "contracts": "1.2.4",
   "dependency-injection": "1.2.5",
   "discover": "1.0.45",
-  "objectquel": "2.6.1",
+  "objectquel": "2.6.2",
   "recommender": "1.0.0",
   "sculpt": "1.0.29",
   "signal-hub": "1.1.1",


### PR DESCRIPTION
extractEntityNameFromFile() regexed the raw file contents for "class\s+(\w+)", so a docblock containing prose like "class from" or "class into" matched before the real declaration, extracting the wrong class name and causing the entity to silently disappear from discovery (no exception, no log line).

Replace the regex with a token_get_all() scan: comments/docblocks tokenize as T_COMMENT/T_DOC_COMMENT and can never be mistaken for the declaration, and Foo::class / anonymous new class {} references are explicitly skipped.