### PR TITLE
Fix sculpt CLI discarding command exit code

### DIFF
--- a/packages/sculpt/src/bin/sculpt
+++ b/packages/sculpt/src/bin/sculpt
@@ -39,13 +39,13 @@
 	/**
 	 * Find the Composer autoloader by traversing up the directory tree
 	 * @param string $startDir The directory to start searching from
-	 * @return array|null Returns [autoloadPath, packageBasePath] if found, null otherwise
+	 * @return array{0: string, 1: string}|null Returns [autoloadPath, packageBasePath] if found, null otherwise
 	 */
 	function findAutoloader(string $startDir): ?array {
 		$dir = $startDir;
-		
+
 		// Continue until we reach the filesystem root
-		while ($dir !== '/' && $dir !== '' && $dir !== false && $dir !== '\\') {
+		while ($dir !== '/' && $dir !== '' && $dir !== '\\') {
 			// Case 1: Check if we're installed as a dependency (inside vendor directory)
 			if (basename(dirname($dir, 2)) === 'vendor') {
 				$autoloadPath = dirname($dir, 3) . '/autoload.php';

--- a/packages/sculpt/src/bin/sculpt
+++ b/packages/sculpt/src/bin/sculpt
@@ -34,7 +34,7 @@
 	$app->discoverProviders();
 	
 	// Run the application with command line arguments
-	$app->run($argv);
+	exit($app->run($argv));
 	
 	/**
 	 * Find the Composer autoloader by traversing up the directory tree

--- a/versioning/versions.json
+++ b/versioning/versions.json
@@ -39,7 +39,7 @@
   "discover": "1.0.45",
   "objectquel": "2.6.2",
   "recommender": "1.0.0",
-  "sculpt": "1.0.30",
+  "sculpt": "1.0.31",
   "signal-hub": "1.1.1",
   "support": "1.2.1"
 }


### PR DESCRIPTION
## Summary
- `src/bin/sculpt` called `Application::run()` as a bare statement and discarded its return value, so the PHP process always exited `0` regardless of what a command's `execute()` returned — breaking CI gates and shell `$?`/`&&`/`||` checks.
- Wrapped the call in `exit()` so the CLI process propagates the command's real exit code.
- Also cleaned up the two pre-existing PHPStan findings in that file: specified the tuple shape returned by `findAutoloader()`, and removed the always-true `$dir !== false` check (`dirname()` never returns `false`).

## Test plan
- [x] `php -l packages/sculpt/src/bin/sculpt`
- [x] `vendor/bin/phpstan analyse packages/sculpt/src/bin/sculpt` — no errors