### PR TITLE
Resolve real column types for temp table joins instead of blanket VARCHAR(255)

### DIFF
--- a/objectquel-temp-table-indexing.md
+++ b/objectquel-temp-table-indexing.md
@@ -1,0 +1,64 @@
+# Temp table indexing for TempTableStage
+
+Source: https://medium.com/@Rohan_Dutt/10-techniques-for-using-temporary-tables-effectively-in-stored-procedures-d4979bad02b0
+
+Reviewed the article's 10 techniques against `TempTableExecutor.php`. Most don't apply
+(SQL Server-only features like table variables/columnstore indexes, or stored-procedure/DBA
+concerns like tempdb monitoring and cross-procedure schema reuse). Batched inserts and
+try/finally cleanup are already handled correctly.
+
+## The one real gap
+
+`createTable()` in `packages/objectquel/src/Execution/Executors/TempTableExecutor.php:164`
+creates every column as `VARCHAR(255)` with no index. The temp table exists specifically to be
+joined against the outer query via `AstRangeDatabaseTempTable::getJoinProperty()`
+(`packages/objectquel/src/ObjectQuel/Ast/AstRangeDatabaseTempTable.php`), so that join currently
+runs as a full scan on the temp table for every outer row.
+
+## Proposed fix
+
+1. After `insertRows()` completes, pull the join column(s) off `$range->getJoinProperty()`.
+   Sanity check first: confirm the join predicate is a plain column reference, not a function
+   expression (e.g. `LOWER(col)`) — a plain `CREATE INDEX` on the column wouldn't be used by a
+   function-wrapped predicate, and would need a functional index instead.
+2. Run `CREATE INDEX` on those column(s) — index-after-insert avoids per-row index maintenance
+   during the batch insert.
+
+Note: index-after-insert is intentional, not an oversight. Indexing an empty table first means
+every batch `INSERT` pays incremental B-tree maintenance (page splits/rebalancing). Building the
+index once after all data is loaded is a single bulk build instead — the same reason MySQL docs
+recommend loading data before adding indexes, and why tools like `mysqldump` add indexes after
+the data load. Only reason to flip the order would be wanting the index in place for partial data
+after a failed batch, which doesn't apply here since `insertRows()` either fully succeeds or
+throws, and `cleanup()` drops the whole table regardless.
+
+## Second real gap: blanket VARCHAR(255) is a design flaw, not just a nice-to-have
+
+Every column is created as `VARCHAR(255)` regardless of its real type (`createTable()`,
+TempTableExecutor.php:164-168). This isn't only an index-usability problem — it's a correctness
+footgun. If the other side of the join is e.g. an `INT` primary key, MySQL may not use the new
+index at all due to implicit type conversion, and numeric/date comparisons routed through a
+VARCHAR column can behave subtly differently than native-typed comparisons. This should be fixed
+alongside the indexing change, not treated as optional follow-up.
+
+Decided: **look up the real type via `Metadata`** (`packages/objectquel/src/Metadata/ColumnData.php`
+already carries per-column declared type off the `@Column` annotation, e.g. the pattern used for
+`softDeleteColumnType`), rather than inferring type from a sampled PHP row value.
+
+Rejected the "infer from PHP value" alternative (sample the first non-null value in
+`insertRows()`'s typed rows and map PHP type → SQL type): it's cheaper but not authoritative —
+it depends on unverified PDO stringification behavior in `DatabaseAdapter`, only samples one row,
+gives no answer for the empty-LEFT-JOIN case where there's no row to sample, and guesses at
+runtime instead of using the entity's actual declared type. Metadata lookup is correct by
+construction and consistent with the project's no-hidden-inference stance — worth the extra
+plumbing (new dependency from `TempTableExecutor` on `Metadata`) to resolve the joined column's
+declared type directly.
+
+## Status
+
+Second gap implemented: `TempTableExecutor` now resolves each projected column's SQL type from
+the source entity's declared `@Column` metadata (via `EntityStore::getMetadata()`), falling back
+to `VARCHAR(255)` only for expressions that don't trace back to a single entity property (function
+calls, computed expressions, literals, empty-LEFT-JOIN projections with no resolvable source).
+
+First gap (indexing the join column(s) after insert) is still not implemented.

--- a/packages/objectquel/src/Execution/Executors/TempTableExecutor.php
+++ b/packages/objectquel/src/Execution/Executors/TempTableExecutor.php
@@ -3,8 +3,12 @@
 	namespace Quellabs\ObjectQuel\Execution\Executors;
 	
 	use Quellabs\ObjectQuel\DatabaseAdapter\DatabaseAdapter;
+	use Quellabs\ObjectQuel\EntityStore;
 	use Quellabs\ObjectQuel\Planner\TempTableStage;
+	use Quellabs\ObjectQuel\ObjectQuel\Ast\AstIdentifier;
 	use Quellabs\ObjectQuel\ObjectQuel\Ast\AstRetrieve;
+	use Quellabs\ObjectQuel\ObjectQuel\AstInterface;
+	use Quellabs\ObjectQuel\Exception\EntityResolutionException;
 	use Quellabs\ObjectQuel\Exception\QuelException;
 	
 	/**
@@ -33,10 +37,10 @@
 	 *     nodes), since there are no result rows to infer the schema from.
 	 *
 	 * Column type inference:
-	 *   All columns are created as VARCHAR(255) NULL on first use. This is intentional:
-	 *   the exact MySQL type does not matter for a session-scoped temporary table that
-	 *   is only used within a single query's execution. Refinement (e.g. detecting
-	 *   INT from PHP int values) can be added later without changing the contract.
+	 *   Each column's SQL type is resolved from the source entity's declared @Column
+	 *   type via EntityStore metadata, when the projected value is a plain entity
+	 *   property reference. Columns that don't trace back to a single entity property
+	 *   (function calls, computed expressions, literals) fall back to VARCHAR(255).
 	 *
 	 * Batch size:
 	 *   Rows are inserted in batches of INSERT_BATCH_SIZE to avoid hitting MySQL's
@@ -54,19 +58,28 @@
 		 * @var DatabaseAdapter
 		 */
 		private DatabaseAdapter $connection;
-		
+
+		/**
+		 * Entity metadata source used to resolve declared column types for the
+		 * temp table schema.
+		 * @var EntityStore
+		 */
+		private EntityStore $entityStore;
+
 		/**
 		 * Names of temporary tables created during this execution, registered for cleanup
 		 * @var string[]
 		 */
 		private array $createdTables = [];
-		
+
 		/**
 		 * TempTableExecutor constructor
 		 * @param DatabaseAdapter $connection
+		 * @param EntityStore $entityStore
 		 */
-		public function __construct(DatabaseAdapter $connection) {
+		public function __construct(DatabaseAdapter $connection, EntityStore $entityStore) {
 			$this->connection = $connection;
+			$this->entityStore = $entityStore;
 		}
 		
 		/**
@@ -105,8 +118,13 @@
 				$columns = array_map(fn($key) => (string)$key, array_keys($rows[0]));
 			}
 			
+			// Resolve each column's SQL type from the source entity's declared
+			// @Column metadata, so joins against typed columns don't run through
+			// implicit VARCHAR conversion (see class docblock).
+			$columnTypes = $this->resolveColumnTypes($innerQuery);
+
 			// Create the temporary table and populate it
-			$this->createTable($tableName, $columns);
+			$this->createTable($tableName, $columns, $columnTypes);
 			
 			if (!empty($rows)) {
 				$this->insertRows($tableName, $columns, $rows);
@@ -153,17 +171,104 @@
 			
 			return $columns;
 		}
-		
+
+		/**
+		 * Resolves the SQL column type for every projected value, keyed by output
+		 * column name (the AstAlias name), by inspecting the query's projection list.
+		 * @param AstRetrieve $query
+		 * @return array<string, string> Column name => SQL type
+		 */
+		private function resolveColumnTypes(AstRetrieve $query): array {
+			$types = [];
+
+			foreach ($query->getValues() as $value) {
+				$types[$value->getName()] = $this->resolveColumnType($value->getExpression());
+			}
+
+			return $types;
+		}
+
+		/**
+		 * Resolves the SQL type for a single projected expression. Only a plain
+		 * entity property reference (e.g. `p.price`) can be traced back to a
+		 * declared @Column type; anything else (function calls, computed
+		 * expressions, literals) falls back to VARCHAR(255).
+		 * @param AstInterface $expression
+		 * @return string
+		 */
+		private function resolveColumnType(AstInterface $expression): string {
+			if (!$expression instanceof AstIdentifier) {
+				return 'VARCHAR(255)';
+			}
+
+			$entityName = $expression->getEntityName();
+
+			if ($entityName === null) {
+				return 'VARCHAR(255)';
+			}
+
+			try {
+				$metadata = $this->entityStore->getMetadata($entityName);
+			} catch (EntityResolutionException) {
+				return 'VARCHAR(255)';
+			}
+
+			$columnName = $metadata->getColumnName($expression->getPropertyName());
+			$columnDefinition = $columnName !== null ? ($metadata->columnDefinitions[$columnName] ?? null) : null;
+
+			if ($columnDefinition === null) {
+				return 'VARCHAR(255)';
+			}
+
+			return $this->sqlTypeFromColumnDefinition($columnDefinition);
+		}
+
+		/**
+		 * Maps a declared @Column definition to a MySQL DDL type fragment.
+		 * @param array{type: string, limit: int|array<int,int>|null, unsigned: bool, precision: int|null, scale: int|null} $columnDefinition
+		 * @return string
+		 */
+		private function sqlTypeFromColumnDefinition(array $columnDefinition): string {
+			$limit = is_int($columnDefinition['limit']) ? $columnDefinition['limit'] : 255;
+			$unsigned = $columnDefinition['unsigned'] ? ' UNSIGNED' : '';
+
+			return match ($columnDefinition['type']) {
+				'tinyinteger' => "TINYINT{$unsigned}",
+				'smallinteger' => "SMALLINT{$unsigned}",
+				'integer' => "INT{$unsigned}",
+				'biginteger' => "BIGINT{$unsigned}",
+				'float' => "FLOAT{$unsigned}",
+				'decimal' => sprintf('DECIMAL(%d,%d)%s', $columnDefinition['precision'] ?? 10, $columnDefinition['scale'] ?? 0, $unsigned),
+				'boolean' => 'TINYINT(1)',
+				'date' => 'DATE',
+				'datetime' => 'DATETIME',
+				'time' => 'TIME',
+				'timestamp' => 'TIMESTAMP',
+				'text' => 'TEXT',
+				'blob' => 'BLOB',
+				'binary' => "VARBINARY({$limit})",
+				'json' => 'JSON',
+				'uuid' => 'CHAR(36)',
+				'year' => 'YEAR',
+				'char' => "CHAR({$limit})",
+				// 'string', 'enum', 'set', and any unrecognized type
+				default => "VARCHAR({$limit})",
+			};
+		}
+
 		/**
 		 * Creates a temporary table with the given name and columns.
-		 * All columns are VARCHAR(255) NULL — see class docblock for rationale.
+		 * Each column uses the SQL type resolved by resolveColumnTypes(), falling
+		 * back to VARCHAR(255) for columns that couldn't be resolved — see class
+		 * docblock for rationale.
 		 * @param string $tableName
 		 * @param string[] $columns
+		 * @param array<string, string> $columnTypes Column name => SQL type
 		 * @throws QuelException
 		 */
-		private function createTable(string $tableName, array $columns): void {
+		private function createTable(string $tableName, array $columns, array $columnTypes): void {
 			$columnDefs = array_map(
-				fn(string $col) => "`{$col}` VARCHAR(255) NULL",
+				fn(string $col) => "`{$col}` " . ($columnTypes[$col] ?? 'VARCHAR(255)') . " NULL",
 				$columns
 			);
 			

--- a/packages/objectquel/src/Execution/PlanExecutor.php
+++ b/packages/objectquel/src/Execution/PlanExecutor.php
@@ -79,7 +79,10 @@
 			$this->databaseExecutor = $queryExecutor->getDatabaseExecutor();
 			$this->jsonExecutor = $queryExecutor->getJsonExecutor();
 			$this->constantExecutor = new ConstantQueryExecutor();
-			$this->tempTableExecutor = new TempTableExecutor($queryExecutor->getConnection());
+			$this->tempTableExecutor = new TempTableExecutor(
+				$queryExecutor->getConnection(),
+				$queryExecutor->getEntityManager()->getEntityStore()
+			);
 		}
 		
 		/**

--- a/tests/ObjectQuel/Integration/TempTableExecutorTest.php
+++ b/tests/ObjectQuel/Integration/TempTableExecutorTest.php
@@ -1,0 +1,221 @@
+<?php
+
+	namespace Quellabs\ObjectQuel\Tests\Integration;
+
+	use App\Entities\PostEntity;
+	use PHPUnit\Framework\TestCase;
+	use Quellabs\ObjectQuel\EntityManager;
+	use Quellabs\ObjectQuel\Execution\Executors\TempTableExecutor;
+	use Quellabs\ObjectQuel\ObjectQuel\Ast\AstAlias;
+	use Quellabs\ObjectQuel\ObjectQuel\Ast\AstIdentifier;
+	use Quellabs\ObjectQuel\ObjectQuel\Ast\AstNumber;
+	use Quellabs\ObjectQuel\ObjectQuel\Ast\AstRangeDatabase;
+	use Quellabs\ObjectQuel\ObjectQuel\Ast\AstRangeDatabaseTempTable;
+	use Quellabs\ObjectQuel\ObjectQuel\Ast\AstRetrieve;
+	use Quellabs\ObjectQuel\ObjectQuel\IdentifierType;
+	use Quellabs\ObjectQuel\Planner\ExecutionPlan;
+	use Quellabs\ObjectQuel\Planner\TempTableStage;
+
+	/**
+	 * TempTableExecutor::createTable() resolves each projected column's SQL type
+	 * from the source entity's declared @Column metadata instead of hardcoding
+	 * VARCHAR(255) for every column (see objectquel-temp-table-indexing.md,
+	 * "second real gap"). These tests run the generated DDL against a live
+	 * MySQL connection and inspect SHOW COLUMNS, since the risk is in the
+	 * generated SQL fragments themselves (e.g. DECIMAL(p,s), VARBINARY(n)),
+	 * not just the PHP-side type-name mapping.
+	 *
+	 * Exercises TempTableExecutor directly rather than through a full
+	 * ObjectQuel query — building the AST by hand for a mixed-source query
+	 * that triggers a real TempTableStage would pull in the whole JSON/planner
+	 * pipeline for no extra coverage of the logic under test. The inner
+	 * query's row producer is stubbed with a plain closure since
+	 * TempTableExecutor only ever calls it and uses the returned rows.
+	 *
+	 * Uses the suite's shared EntityManager/EntityStore ($GLOBALS['test_em'])
+	 * — see CascadeStrategyTest for why only one EntityManager may exist per
+	 * PHPUnit process — and the App\Entities\PostEntity fixture, which already
+	 * declares unsigned integer, string/limit, text, boolean, and datetime
+	 * columns.
+	 */
+	class TempTableExecutorTest extends TestCase {
+
+		private static int $tableCounter = 0;
+
+		private TempTableExecutor $executor;
+
+		private static function em(): EntityManager {
+			return $GLOBALS['test_em'];
+		}
+
+		protected function setUp(): void {
+			$this->executor = new TempTableExecutor(
+				self::em()->getConnection(),
+				self::em()->getEntityStore()
+			);
+		}
+
+		protected function tearDown(): void {
+			// Drops every temp table created across all tests in this instance,
+			// not just the last one — cleanup() clears its own registry, and
+			// each test gets a fresh TempTableExecutor, so this only ever
+			// touches tables the current test created.
+			$this->executor->cleanup();
+		}
+
+		/**
+		 * A unique table name per call, so tests never collide on a leftover
+		 * temp table from a previous run in the same session.
+		 */
+		private function nextTableName(): string {
+			return 'tmp_ttx_test_' . getmypid() . '_' . (++self::$tableCounter);
+		}
+
+		/**
+		 * Builds a `<range>.<property>` projected value: an AstAlias whose
+		 * expression is the base AstIdentifier of the chain with the range
+		 * attached directly to it — exactly how the parser wires a resolved
+		 * property reference (see ResolveIdentifierRange).
+		 */
+		private function propertyValue(string $outputName, string $property, AstRangeDatabase $range): AstAlias {
+			$base = new AstIdentifier($range->getName(), IdentifierType::EntityRoot);
+			$base->setRange($range);
+			$base->setNext(new AstIdentifier($property));
+
+			return new AstAlias($outputName, $base);
+		}
+
+		/**
+		 * @return array<string, string> Column name => lowercased SHOW COLUMNS type
+		 */
+		private function describeColumns(string $tableName): array {
+			$rows = self::em()->getConnection()
+				->execute("SHOW COLUMNS FROM `{$tableName}`")
+				->fetchAll('assoc');
+
+			$columns = [];
+
+			foreach ($rows as $row) {
+				$columns[$row['Field']] = strtolower($row['Type']);
+			}
+
+			return $columns;
+		}
+
+		public function testResolvesDeclaredColumnTypesFromEntityMetadata(): void {
+			$range = new AstRangeDatabase('p', PostEntity::class);
+			$innerQuery = new AstRetrieve([], [$range], false);
+			$innerQuery->addValue($this->propertyValue('id', 'id', $range));
+			$innerQuery->addValue($this->propertyValue('title', 'title', $range));
+			$innerQuery->addValue($this->propertyValue('content', 'content', $range));
+			$innerQuery->addValue($this->propertyValue('published', 'published', $range));
+			$innerQuery->addValue($this->propertyValue('created_at', 'createdAt', $range));
+
+			$tableName = $this->nextTableName();
+			$tempTableRange = new AstRangeDatabaseTempTable('p_tmp', $innerQuery, $tableName);
+			$stage = new TempTableStage('stage', $tempTableRange, new ExecutionPlan());
+
+			$rows = [[
+				'id'         => 1,
+				'title'      => 'Hello',
+				'content'    => 'World',
+				'published'  => 1,
+				'created_at' => '2024-01-01 12:00:00',
+			]];
+
+			$this->executor->execute($stage, fn() => $rows);
+
+			$columns = $this->describeColumns($tableName);
+
+			self::assertSame('int unsigned', $columns['id']);
+			self::assertSame('varchar(255)', $columns['title']);
+			self::assertSame('text', $columns['content']);
+			self::assertSame('tinyint(1)', $columns['published']);
+			self::assertSame('datetime', $columns['created_at']);
+
+			// The typed columns must still be usable for their declared purpose,
+			// not just correctly labelled.
+			$inserted = self::em()->getConnection()
+				->execute("SELECT * FROM `{$tableName}`")
+				->fetchAll('assoc');
+
+			self::assertSame('1', (string)$inserted[0]['id']);
+			self::assertSame('Hello', $inserted[0]['title']);
+		}
+
+		public function testFallsBackToVarcharForExpressionsThatArentEntityProperties(): void {
+			$range = new AstRangeDatabase('p', PostEntity::class);
+			$innerQuery = new AstRetrieve([], [$range], false);
+			$innerQuery->addValue($this->propertyValue('id', 'id', $range));
+			$innerQuery->addValue(new AstAlias('literal_col', new AstNumber('42')));
+
+			$tableName = $this->nextTableName();
+			$tempTableRange = new AstRangeDatabaseTempTable('p_tmp', $innerQuery, $tableName);
+			$stage = new TempTableStage('stage', $tempTableRange, new ExecutionPlan());
+
+			$rows = [[
+				'id'          => 1,
+				'literal_col' => '42',
+			]];
+
+			$this->executor->execute($stage, fn() => $rows);
+
+			$columns = $this->describeColumns($tableName);
+
+			// Resolvable column still gets its real type...
+			self::assertSame('int unsigned', $columns['id']);
+
+			// ...while the computed expression falls back, rather than guessing.
+			self::assertSame('varchar(255)', $columns['literal_col']);
+		}
+
+		/**
+		 * Covers the empty-LEFT-JOIN case the design doc calls out as the
+		 * reason PHP-value inference was rejected: with zero rows to sample,
+		 * Metadata-based resolution still produces a correctly typed table.
+		 */
+		public function testEmptyLeftJoinResultStillProducesTypedTable(): void {
+			$range = new AstRangeDatabase('p', PostEntity::class);
+			$innerQuery = new AstRetrieve([], [$range], false);
+			$innerQuery->addValue($this->propertyValue('id', 'id', $range));
+			$innerQuery->addValue($this->propertyValue('published', 'published', $range));
+
+			$tableName = $this->nextTableName();
+
+			// $required = false reproduces a LEFT JOIN range: PlanExecutor must
+			// still create the (empty) temp table so the outer query's LEFT
+			// JOIN sees a real, correctly-typed table instead of failing.
+			$tempTableRange = new AstRangeDatabaseTempTable('p_tmp', $innerQuery, $tableName, null, false);
+			$stage = new TempTableStage('stage', $tempTableRange, new ExecutionPlan());
+
+			$this->executor->execute($stage, fn() => []);
+
+			$columns = $this->describeColumns($tableName);
+
+			self::assertSame('int unsigned', $columns['id']);
+			self::assertSame('tinyint(1)', $columns['published']);
+		}
+
+		public function testRequiredInnerJoinWithNoRowsSkipsTableCreationEntirely(): void {
+			$range = new AstRangeDatabase('p', PostEntity::class);
+			$innerQuery = new AstRetrieve([], [$range], false);
+			$innerQuery->addValue($this->propertyValue('id', 'id', $range));
+
+			$tableName = $this->nextTableName();
+
+			// $required = true reproduces an INNER JOIN range: no table should
+			// be created at all when the inner query returns no rows.
+			$tempTableRange = new AstRangeDatabaseTempTable('p_tmp', $innerQuery, $tableName, null, true);
+			$stage = new TempTableStage('stage', $tempTableRange, new ExecutionPlan());
+
+			$this->executor->execute($stage, fn() => []);
+
+			// SHOW TABLES never lists TEMPORARY tables regardless of whether one
+			// was created, so it can't tell us anything here. DatabaseAdapter::execute()
+			// swallows the underlying "table doesn't exist" exception and returns
+			// null instead, which is the observable signal that no table exists.
+			$result = self::em()->getConnection()->execute("SELECT 1 FROM `{$tableName}` LIMIT 1");
+
+			self::assertNull($result);
+		}
+	}

--- a/tests/ObjectQuel/Integration/TempTableExecutorTest.php
+++ b/tests/ObjectQuel/Integration/TempTableExecutorTest.php
@@ -45,7 +45,13 @@
 		private TempTableExecutor $executor;
 
 		private static function em(): EntityManager {
-			return $GLOBALS['test_em'];
+			$em = $GLOBALS['test_em'];
+
+			if (!$em instanceof EntityManager) {
+				throw new \RuntimeException("Test bootstrap did not initialize \$GLOBALS['test_em']");
+			}
+
+			return $em;
 		}
 
 		protected function setUp(): void {
@@ -86,17 +92,44 @@
 		}
 
 		/**
+		 * Runs a query expected to succeed and returns its rows. DatabaseAdapter::execute()
+		 * swallows the underlying exception and returns null on failure instead of
+		 * throwing, so a null result here means the query itself is broken — fail
+		 * loudly rather than pass a null into fetchAll().
+		 * @return array<int, array<string, mixed>>
+		 */
+		private function fetchAllAssoc(string $sql): array {
+			$statement = self::em()->getConnection()->execute($sql);
+
+			if ($statement === null) {
+				throw new \RuntimeException("Query failed: {$sql}");
+			}
+
+			return $statement->fetchAll('assoc');
+		}
+
+		/**
+		 * Narrows a single database result-set value (always scalar or null for
+		 * the columns these tests read) to a string for comparison.
+		 */
+		private function scalarToString(mixed $value): string {
+			return match (true) {
+				is_string($value) => $value,
+				is_int($value), is_float($value) => (string)$value,
+				is_bool($value) => $value ? '1' : '0',
+				$value === null => '',
+				default => throw new \RuntimeException('Unexpected non-scalar value from query result: ' . get_debug_type($value)),
+			};
+		}
+
+		/**
 		 * @return array<string, string> Column name => lowercased SHOW COLUMNS type
 		 */
 		private function describeColumns(string $tableName): array {
-			$rows = self::em()->getConnection()
-				->execute("SHOW COLUMNS FROM `{$tableName}`")
-				->fetchAll('assoc');
-
 			$columns = [];
 
-			foreach ($rows as $row) {
-				$columns[$row['Field']] = strtolower($row['Type']);
+			foreach ($this->fetchAllAssoc("SHOW COLUMNS FROM `{$tableName}`") as $row) {
+				$columns[$this->scalarToString($row['Field'])] = strtolower($this->scalarToString($row['Type']));
 			}
 
 			return $columns;
@@ -135,12 +168,10 @@
 
 			// The typed columns must still be usable for their declared purpose,
 			// not just correctly labelled.
-			$inserted = self::em()->getConnection()
-				->execute("SELECT * FROM `{$tableName}`")
-				->fetchAll('assoc');
+			$inserted = $this->fetchAllAssoc("SELECT * FROM `{$tableName}`");
 
-			self::assertSame('1', (string)$inserted[0]['id']);
-			self::assertSame('Hello', $inserted[0]['title']);
+			self::assertSame('1', $this->scalarToString($inserted[0]['id']));
+			self::assertSame('Hello', $this->scalarToString($inserted[0]['title']));
 		}
 
 		public function testFallsBackToVarcharForExpressionsThatArentEntityProperties(): void {

--- a/versioning/versions.json
+++ b/versioning/versions.json
@@ -37,7 +37,7 @@
   "contracts": "1.2.4",
   "dependency-injection": "1.2.5",
   "discover": "1.1.0",
-  "objectquel": "2.8.3",
+  "objectquel": "2.8.4",
   "recommender": "1.0.0",
   "sculpt": "1.0.31",
   "signal-hub": "1.1.1",


### PR DESCRIPTION
## Summary
- `TempTableExecutor` no longer hardcodes every temp-table column as `VARCHAR(255)`. It now resolves each projected column's SQL type from the source entity's declared `@Column` metadata (via `EntityStore`), falling back to `VARCHAR(255)` only for expressions that don't trace back to a single entity property (function calls, computed expressions, literals).
- This fixes a correctness footgun, not just an index-usability nit: joining a mistyped `VARCHAR` temp-table column against a native `INT`/`DATETIME`/etc. column can silently skip indexes or behave differently under implicit type conversion.
- `PlanExecutor` now passes `EntityStore` through to `TempTableExecutor`'s constructor.
- Design rationale and rejected alternatives documented in `objectquel-temp-table-indexing.md` (the join-column-indexing gap noted there is a separate, not-yet-implemented follow-up).

## Test plan
- [x] New `tests/ObjectQuel/Integration/TempTableExecutorTest.php` — 4 tests run against a live MySQL connection and inspect `SHOW COLUMNS` on the generated temp table:
  - resolves declared entity column types (int unsigned, varchar(255), text, tinyint(1), datetime) and confirms inserted data round-trips
  - falls back to `VARCHAR(255)` for a literal/computed projection while resolvable columns still get their real type
  - empty-LEFT-JOIN case (zero rows to sample) still produces a correctly typed table
  - required INNER JOIN with zero rows still skips table creation entirely
- [x] Verified the tests catch the regression: temporarily forced type resolution back to always-`VARCHAR(255)` and confirmed 3 of 4 tests failed, then restored the fix
- [x] Full `ObjectQuel` suite: 383 tests, 833 assertions, green
- [x] `phpstan analyse` (project config, level 9): no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012nA93mo6ZrpQ7EyLAavauk