### PR TITLE
Make ObjectQuel SQL generation portable across supported engines

### DIFF
--- a/packages/objectquel/src/Capabilities/JsonExtractionStyle.php
+++ b/packages/objectquel/src/Capabilities/JsonExtractionStyle.php
@@ -12,7 +12,8 @@
 	 *                     Supported by: PostgreSQL (all versions)
 	 *
 	 * - JsonValue       → JSON_VALUE(col, '$.a.b')
-	 *                     Supported by: MariaDB >= 10.9
+	 *                     Supported by: MariaDB >= 10.9, SQL Server (all versions
+	 *                     targeted here — available since SQL Server 2016)
 	 *                     SQLite has no JSON_VALUE() function at any version — use
 	 *                     ArrowOperator for SQLite >= 3.38 instead.
 	 *

--- a/packages/objectquel/src/Capabilities/NullPlatformCapabilities.php
+++ b/packages/objectquel/src/Capabilities/NullPlatformCapabilities.php
@@ -1,7 +1,7 @@
 <?php
 	
 	namespace Quellabs\ObjectQuel\Capabilities;
-	
+
 	/**
 	 * Conservative no-op platform used when no database connection is available.
 	 *
@@ -170,5 +170,17 @@
 		 */
 		public function supportsForeignKeyIntrospection(): bool {
 			return false;
+		}
+
+		/**
+		 * @inheritDoc
+		 *
+		 * Defaults to 'mysql', the most widely deployed engine in the
+		 * Canvas/ObjectQuel target stack. Callers that need the real engine must
+		 * inject a real PlatformCapabilities instance instead of relying on this
+		 * null implementation.
+		 */
+		public function getDatabaseType(): string {
+			return 'mysql';
 		}
 	}

--- a/packages/objectquel/src/Capabilities/NullPlatformCapabilities.php
+++ b/packages/objectquel/src/Capabilities/NullPlatformCapabilities.php
@@ -99,23 +99,6 @@
 		/**
 		 * @inheritDoc
 		 *
-		 * Returns the baseline cast types supported by MySQL/MariaDB, which are the
-		 * most conservative valid set. Callers that need engine-specific types should
-		 * inject a real PlatformCapabilities instance instead of relying on this null
-		 * implementation.
-		 */
-		public function getSupportedCastTypes(): array {
-			return [
-				'int'     => 'SIGNED',
-				'float'   => 'DOUBLE',
-				'string'  => 'CHAR',
-				'decimal' => 'DECIMAL',
-			];
-		}
-
-		/**
-		 * @inheritDoc
-		 *
 		 * Defaults to MySQL/MariaDB syntax, the most widely deployed engine in the
 		 * Canvas/ObjectQuel target stack.
 		 */

--- a/packages/objectquel/src/Capabilities/PlatformCapabilities.php
+++ b/packages/objectquel/src/Capabilities/PlatformCapabilities.php
@@ -246,48 +246,6 @@
 		/**
 		 * @inheritDoc
 		 *
-		 * Cast type maps per engine:
-		 *
-		 * MySQL / MariaDB
-		 *   Integer arithmetic uses SIGNED (signed 64-bit) rather than INT because
-		 *   CAST(x AS INT) is not valid in MySQL; SIGNED / UNSIGNED are the correct
-		 *   integer target types for CAST().
-		 *
-		 * PostgreSQL
-		 *   Uses standard ANSI type names. INTEGER and FLOAT are the idiomatic choices;
-		 *   TEXT is preferred over VARCHAR (no length constraint) for string casts.
-		 *
-		 * SQLite
-		 *   SQLite CAST() accepts a limited set of type affinities: INTEGER, REAL,
-		 *   TEXT, NUMERIC, BLOB. There is no separate FLOAT or DOUBLE type.
-		 */
-		public function getSupportedCastTypes(): array {
-			return match ($this->adapter->getDatabaseType()) {
-				'pgsql' => [
-					'int'     => 'INTEGER',
-					'float'   => 'FLOAT',
-					'string'  => 'TEXT',
-					'decimal' => 'DECIMAL',
-					'bool'    => 'BOOLEAN',
-				],
-				'sqlite' => [
-					'int'     => 'INTEGER',
-					'float'   => 'REAL',
-					'string'  => 'TEXT',
-					'decimal' => 'NUMERIC',
-				],
-				default => [
-					'int'     => 'SIGNED',
-					'float'   => 'DOUBLE',
-					'string'  => 'CHAR',
-					'decimal' => 'DECIMAL',
-				],
-			};
-		}
-		
-		/**
-		 * @inheritDoc
-		 *
 		 * Unix timestamp conversion function per engine:
 		 * - MySQL / MariaDB: UNIX_TIMESTAMP(col)
 		 * - PostgreSQL:      EXTRACT(EPOCH FROM col)::BIGINT

--- a/packages/objectquel/src/Capabilities/PlatformCapabilities.php
+++ b/packages/objectquel/src/Capabilities/PlatformCapabilities.php
@@ -11,6 +11,12 @@
 	 * available at runtime. Construct this once (typically alongside your
 	 * EntityManager) and pass it into QuelToSQL.
 	 *
+	 * This class only reports facts about the connected engine (booleans,
+	 * tokens, and getDatabaseType() itself) — it never builds SQL text.
+	 * Collaborators that render whole DDL/SQL fragments from those facts (e.g.
+	 * DDLTypeMapper) take a PlatformCapabilitiesInterface and query it, rather
+	 * than this class delegating out to them.
+	 *
 	 * Example:
 	 *   $platform = new PlatformCapabilities($adapter);
 	 *   $quelToSQL = new QuelToSQL($entityStore, $parameters, $platform);
@@ -348,6 +354,13 @@
 		 */
 		public function supportsForeignKeyIntrospection(): bool {
 			return in_array($this->adapter->getDatabaseType(), ['mysql', 'mariadb', 'sqlite', 'pgsql', 'sqlsrv']);
+		}
+
+		/**
+		 * @inheritDoc
+		 */
+		public function getDatabaseType(): string {
+			return $this->adapter->getDatabaseType();
 		}
 
 		/**

--- a/packages/objectquel/src/Capabilities/PlatformCapabilities.php
+++ b/packages/objectquel/src/Capabilities/PlatformCapabilities.php
@@ -220,6 +220,8 @@
 		 * JSON path extraction style depends on the engine and version:
 		 * - PostgreSQL:       col #>> '{a,b}'          (all versions)
 		 * - MariaDB >= 10.9:  JSON_VALUE(col, '$.a.b')
+		 * - SQL Server:       JSON_VALUE(col, '$.a.b') (available since SQL Server
+		 *                     2016; same function/path syntax as MariaDB's)
 		 * - SQLite >= 3.38:   col ->> '$.a.b'          (SQLite has no JSON_VALUE())
 		 * - All others:       JSON_UNQUOTE(JSON_EXTRACT(col, '$.a.b'))
 		 */
@@ -227,17 +229,20 @@
 			switch ($this->adapter->getDatabaseType()) {
 				case 'pgsql':
 					return JsonExtractionStyle::HashDoubleArrow;
-				
+
 				case 'mariadb':
 					return $this->supportsMariaDbJsonValue()
 						? JsonExtractionStyle::JsonValue
 						: JsonExtractionStyle::JsonUnquote;
-				
+
+				case 'sqlsrv':
+					return JsonExtractionStyle::JsonValue;
+
 				case 'sqlite':
 					return $this->supportsSqliteArrowOperator()
 						? JsonExtractionStyle::ArrowOperator
 						: JsonExtractionStyle::JsonUnquote;
-				
+
 				default:
 					return JsonExtractionStyle::JsonUnquote;
 			}

--- a/packages/objectquel/src/Capabilities/PlatformCapabilitiesInterface.php
+++ b/packages/objectquel/src/Capabilities/PlatformCapabilitiesInterface.php
@@ -242,4 +242,18 @@
 		 * @return bool
 		 */
 		public function supportsForeignKeyIntrospection(): bool;
+
+		/**
+		 * Returns the connected database engine's type identifier.
+		 *
+		 * This is the most basic fact PlatformCapabilities reports — every other
+		 * method here is, internally, a decision made from this same value. It's
+		 * exposed directly so collaborators that build engine-specific SQL text
+		 * from scratch (e.g. DDLTypeMapper's temporary-table DDL) can branch on
+		 * the engine without PlatformCapabilities having to grow a bespoke
+		 * reporting method for every syntax difference between engines.
+		 *
+		 * @return string One of 'mysql', 'mariadb', 'pgsql', 'sqlite', 'sqlsrv'
+		 */
+		public function getDatabaseType(): string;
 	}

--- a/packages/objectquel/src/Capabilities/PlatformCapabilitiesInterface.php
+++ b/packages/objectquel/src/Capabilities/PlatformCapabilitiesInterface.php
@@ -118,21 +118,6 @@
 		 * @return JsonExtractionStyle
 		 */
 		public function getJsonExtractionStyle(): JsonExtractionStyle;
-		/**
-		 * Returns the set of QUEL cast type names supported by the connected engine,
-		 * mapped to the SQL type token that should appear inside the CAST expression.
-		 *
-		 * The keys are the identifiers users write in QUEL (e.g. 'int', 'float',
-		 * 'string', 'decimal'). The values are the exact SQL type tokens emitted
-		 * into the generated SQL (e.g. 'SIGNED', 'DOUBLE', 'CHAR', 'DECIMAL').
-		 *
-		 * ObjectQuel validates cast types against this map at semantic-analysis time
-		 * and rejects any cast whose key is absent, so only engine-supported casts
-		 * can reach the SQL generator.
-		 *
-		 * @return array<string, string>  e.g. ['int' => 'SIGNED', 'float' => 'DOUBLE', ...]
-		 */
-		public function getSupportedCastTypes(): array;
 
 		/**
 		 * Returns a SQL expression that converts a datetime column or value to a

--- a/packages/objectquel/src/DatabaseAdapter/CastTypeMapper.php
+++ b/packages/objectquel/src/DatabaseAdapter/CastTypeMapper.php
@@ -1,0 +1,105 @@
+<?php
+
+	namespace Quellabs\ObjectQuel\DatabaseAdapter;
+
+	use Quellabs\ObjectQuel\Capabilities\PlatformCapabilitiesInterface;
+
+	/**
+	 * Maps canonical QUEL cast type keywords ('int', 'float', 'string',
+	 * 'decimal', 'bool') to the SQL type token that should appear inside a
+	 * CAST(... AS <token>) expression on the connected engine.
+	 *
+	 * Like DDLTypeMapper (temp-table DDL) and SqlIdentifierQuoter (identifier
+	 * quoting), this renders SQL text from a PlatformCapabilitiesInterface's
+	 * reported facts rather than living on PlatformCapabilities itself — a
+	 * per-abstract-type lookup table is a different kind of thing than a
+	 * capability fact. Used by SemanticAnalyzer (to validate a cast type is
+	 * supported before it reaches SQL generation) and BuildSqlFromAst (to
+	 * render the CAST() expression).
+	 */
+	class CastTypeMapper {
+
+		/**
+		 * @var PlatformCapabilitiesInterface
+		 */
+		private PlatformCapabilitiesInterface $platform;
+
+		/**
+		 * CastTypeMapper constructor
+		 * @param PlatformCapabilitiesInterface $platform
+		 */
+		public function __construct(PlatformCapabilitiesInterface $platform) {
+			$this->platform = $platform;
+		}
+
+		/**
+		 * Returns the set of QUEL cast type names supported by the connected
+		 * engine, mapped to the SQL type token that should appear inside the
+		 * CAST expression.
+		 *
+		 * The keys are the identifiers users write in QUEL (e.g. 'int', 'float',
+		 * 'string', 'decimal'). The values are the exact SQL type tokens emitted
+		 * into the generated SQL (e.g. 'SIGNED', 'DOUBLE', 'CHAR', 'DECIMAL').
+		 * SemanticAnalyzer validates cast types against this map and rejects any
+		 * cast whose key is absent, so only engine-supported casts reach
+		 * BuildSqlFromAst's SQL generator.
+		 *
+		 * Cast type maps per engine:
+		 *
+		 * MySQL / MariaDB
+		 *   Integer arithmetic uses SIGNED (signed 64-bit) rather than INT because
+		 *   CAST(x AS INT) is not valid in MySQL; SIGNED / UNSIGNED are the correct
+		 *   integer target types for CAST(). Also the fallback for any other
+		 *   database type value this class doesn't otherwise recognise.
+		 *
+		 * PostgreSQL
+		 *   Uses standard ANSI type names. INTEGER and FLOAT are the idiomatic choices;
+		 *   TEXT is preferred over VARCHAR (no length constraint) for string casts.
+		 *
+		 * SQLite
+		 *   SQLite CAST() accepts a limited set of type affinities: INTEGER, REAL,
+		 *   TEXT, NUMERIC, BLOB. There is no separate FLOAT or DOUBLE type.
+		 *
+		 * SQL Server
+		 *   T-SQL has no SIGNED/DOUBLE types at all (those are MySQL-only CAST
+		 *   keywords) — INT and FLOAT are the correct targets. CHAR is avoided for
+		 *   string casts: CAST(x AS CHAR) with no length silently defaults to
+		 *   CHAR(30) in T-SQL (unlike MySQL, where bare CHAR doesn't truncate), so
+		 *   NVARCHAR(MAX) is used instead. BIT is included (unlike MySQL/MariaDB,
+		 *   which have no CAST-to-boolean target at all) since SQL Server does have
+		 *   a real boolean-ish type here.
+		 *
+		 * @return array<string, string> e.g. ['int' => 'SIGNED', 'float' => 'DOUBLE', ...]
+		 */
+		public function getSupportedCastTypes(): array {
+			return match ($this->platform->getDatabaseType()) {
+				'pgsql' => [
+					'int'     => 'INTEGER',
+					'float'   => 'FLOAT',
+					'string'  => 'TEXT',
+					'decimal' => 'DECIMAL',
+					'bool'    => 'BOOLEAN',
+				],
+				'sqlite' => [
+					'int'     => 'INTEGER',
+					'float'   => 'REAL',
+					'string'  => 'TEXT',
+					'decimal' => 'NUMERIC',
+				],
+				'sqlsrv' => [
+					'int'     => 'INT',
+					'float'   => 'FLOAT',
+					'string'  => 'NVARCHAR(MAX)',
+					'decimal' => 'DECIMAL',
+					'bool'    => 'BIT',
+				],
+				// MySQL/MariaDB, and the fallback for any other database type
+				default => [
+					'int'     => 'SIGNED',
+					'float'   => 'DOUBLE',
+					'string'  => 'CHAR',
+					'decimal' => 'DECIMAL',
+				],
+			};
+		}
+	}

--- a/packages/objectquel/src/DatabaseAdapter/DDLTypeMapper.php
+++ b/packages/objectquel/src/DatabaseAdapter/DDLTypeMapper.php
@@ -1,0 +1,232 @@
+<?php
+
+	namespace Quellabs\ObjectQuel\DatabaseAdapter;
+
+	use Quellabs\ObjectQuel\Capabilities\PlatformCapabilitiesInterface;
+
+	/**
+	 * Renders engine-specific SQL DDL fragments for session-scoped temporary
+	 * tables, driven by a PlatformCapabilitiesInterface's reported facts.
+	 *
+	 * Unlike TypeMapper (which maps abstract @Column types to PHP types and is
+	 * engine-agnostic), this maps them to literal engine-specific SQL syntax —
+	 * e.g. no UNSIGNED modifier outside MySQL/MariaDB, no TINYINT/YEAR on
+	 * PostgreSQL or SQL Server, native BOOLEAN/UUID/BYTEA types on PostgreSQL
+	 * instead of TINYINT(1)/CHAR(36)/BLOB. PlatformCapabilitiesInterface itself
+	 * only reports facts (booleans, tokens, getDatabaseType()) and never builds
+	 * SQL text — this class is where those facts turn into actual SQL.
+	 *
+	 * Used only by TempTableExecutor. Identifier/alias quoting is a separate,
+	 * non-DDL concern (every SQL statement needs it, not just DDL) and lives in
+	 * SqlIdentifierQuoter instead — QuelToSQL, which never emits DDL, depends
+	 * on that class, not this one.
+	 */
+	class DDLTypeMapper {
+
+		/**
+		 * @var PlatformCapabilitiesInterface
+		 */
+		private PlatformCapabilitiesInterface $platform;
+
+		/**
+		 * DDLTypeMapper constructor
+		 * @param PlatformCapabilitiesInterface $platform
+		 */
+		public function __construct(PlatformCapabilitiesInterface $platform) {
+			$this->platform = $platform;
+		}
+
+		/**
+		 * Returns the physical table name to use for a session-scoped temporary
+		 * table, given the logical base name.
+		 *
+		 * Every supported engine except SQL Server creates temporary tables by
+		 * name exactly as given, distinguished from permanent tables only by the
+		 * CREATE/DROP keyword (see getCreateTempTableKeyword()/getDropTempTableKeyword()).
+		 * SQL Server has no such keyword: a "local temporary table" is identified
+		 * purely by a leading '#' in its name. Callers must use the name this
+		 * method returns for every subsequent reference to the table (DDL, DML,
+		 * and any later SQL that reads from it) — not just the CREATE statement.
+		 *
+		 * @param string $baseName Logical temp table name, e.g. 'tmp_range_abc123'
+		 * @return string The physical name to create and reference
+		 */
+		public function getTempTableName(string $baseName): string {
+			return $this->platform->getDatabaseType() === 'sqlsrv' ? "#{$baseName}" : $baseName;
+		}
+
+		/**
+		 * Returns the CREATE-statement keyword sequence for a session-scoped
+		 * temporary table, up to but not including the table name.
+		 *
+		 * Examples by engine:
+		 *   MySQL/MariaDB/PostgreSQL/SQLite → 'CREATE TEMPORARY TABLE'
+		 *   SQL Server                      → 'CREATE TABLE' (temp-ness comes from
+		 *                                      the '#' prefix in getTempTableName())
+		 *
+		 * @return string
+		 */
+		public function getCreateTempTableKeyword(): string {
+			return $this->platform->getDatabaseType() === 'sqlsrv' ? 'CREATE TABLE' : 'CREATE TEMPORARY TABLE';
+		}
+
+		/**
+		 * Returns the DROP-statement keyword sequence for a session-scoped
+		 * temporary table, up to but not including the table name.
+		 *
+		 * Only MySQL/MariaDB accept the TEMPORARY keyword in DROP TABLE; every
+		 * other engine rejects it there even though it's required (or, for SQL
+		 * Server, irrelevant) in CREATE.
+		 *
+		 * Examples by engine:
+		 *   MySQL/MariaDB                        → 'DROP TEMPORARY TABLE IF EXISTS'
+		 *   PostgreSQL/SQLite/SQL Server          → 'DROP TABLE IF EXISTS'
+		 *
+		 * @return string
+		 */
+		public function getDropTempTableKeyword(): string {
+			return in_array($this->platform->getDatabaseType(), ['mysql', 'mariadb'])
+				? 'DROP TEMPORARY TABLE IF EXISTS'
+				: 'DROP TABLE IF EXISTS';
+		}
+
+		/**
+		 * Maps a declared @Column definition to a DDL type fragment valid for a
+		 * CREATE TABLE column definition on the connected engine.
+		 * @param array{type: string, limit: int|array<int,int>|null, unsigned: bool, precision: int|null, scale: int|null} $columnDefinition
+		 * @return string
+		 */
+		public function getTempTableColumnType(array $columnDefinition): string {
+			return match ($this->platform->getDatabaseType()) {
+				'pgsql' => $this->getPostgresTempTableColumnType($columnDefinition),
+				'sqlite' => $this->getSqliteTempTableColumnType($columnDefinition),
+				'sqlsrv' => $this->getSqlServerTempTableColumnType($columnDefinition),
+				default => $this->getMysqlTempTableColumnType($columnDefinition),
+			};
+		}
+
+		/**
+		 * MySQL/MariaDB DDL type mapping. Also the fallback for any database
+		 * type value this class doesn't otherwise recognise.
+		 * @param array{type: string, limit: int|array<int,int>|null, unsigned: bool, precision: int|null, scale: int|null} $columnDefinition
+		 * @return string
+		 */
+		private function getMysqlTempTableColumnType(array $columnDefinition): string {
+			$limit = is_int($columnDefinition['limit']) ? $columnDefinition['limit'] : 255;
+			$unsigned = $columnDefinition['unsigned'] ? ' UNSIGNED' : '';
+
+			return match ($columnDefinition['type']) {
+				'tinyinteger' => "TINYINT{$unsigned}",
+				'smallinteger' => "SMALLINT{$unsigned}",
+				'integer' => "INT{$unsigned}",
+				'biginteger' => "BIGINT{$unsigned}",
+				'float' => "FLOAT{$unsigned}",
+				'decimal' => sprintf('DECIMAL(%d,%d)%s', $columnDefinition['precision'] ?? 10, $columnDefinition['scale'] ?? 0, $unsigned),
+				'boolean' => 'TINYINT(1)',
+				'date' => 'DATE',
+				'datetime' => 'DATETIME',
+				'time' => 'TIME',
+				'timestamp' => 'TIMESTAMP',
+				'text' => 'TEXT',
+				'blob' => 'BLOB',
+				'binary' => "VARBINARY({$limit})",
+				'json' => 'JSON',
+				'uuid' => 'CHAR(36)',
+				'year' => 'YEAR',
+				'char' => "CHAR({$limit})",
+				// 'string', 'enum', 'set', and any unrecognized type
+				default => "VARCHAR({$limit})",
+			};
+		}
+
+		/**
+		 * PostgreSQL DDL type mapping. No UNSIGNED modifier, no TINYINT/YEAR;
+		 * native BOOLEAN/UUID/BYTEA types replace MySQL's TINYINT(1)/CHAR(36)/BLOB.
+		 * @param array{type: string, limit: int|array<int,int>|null, unsigned: bool, precision: int|null, scale: int|null} $columnDefinition
+		 * @return string
+		 */
+		private function getPostgresTempTableColumnType(array $columnDefinition): string {
+			$limit = is_int($columnDefinition['limit']) ? $columnDefinition['limit'] : 255;
+
+			return match ($columnDefinition['type']) {
+				// PostgreSQL has no 1-byte integer type; SMALLINT is the closest fit.
+				'tinyinteger', 'smallinteger', 'year' => 'SMALLINT',
+				'integer' => 'INTEGER',
+				'biginteger' => 'BIGINT',
+				'float' => 'REAL',
+				'decimal' => sprintf('DECIMAL(%d,%d)', $columnDefinition['precision'] ?? 10, $columnDefinition['scale'] ?? 0),
+				'boolean' => 'BOOLEAN',
+				'date' => 'DATE',
+				'datetime', 'timestamp' => 'TIMESTAMP',
+				'time' => 'TIME',
+				'text' => 'TEXT',
+				'blob', 'binary' => 'BYTEA',
+				'json' => 'JSONB',
+				'uuid' => 'UUID',
+				'char' => "CHAR({$limit})",
+				// 'string', 'enum', 'set', and any unrecognized type
+				default => "VARCHAR({$limit})",
+			};
+		}
+
+		/**
+		 * SQLite DDL type mapping. SQLite derives storage affinity from the type
+		 * name rather than enforcing a fixed type system, so this only needs to
+		 * avoid syntax SQLite doesn't parse (e.g. UNSIGNED) — it does not need a
+		 * distinct type name per case the way the other engines do.
+		 * @param array{type: string, limit: int|array<int,int>|null, unsigned: bool, precision: int|null, scale: int|null} $columnDefinition
+		 * @return string
+		 */
+		private function getSqliteTempTableColumnType(array $columnDefinition): string {
+			$limit = is_int($columnDefinition['limit']) ? $columnDefinition['limit'] : 255;
+
+			return match ($columnDefinition['type']) {
+				'tinyinteger', 'smallinteger', 'integer', 'biginteger', 'year' => 'INTEGER',
+				'float' => 'REAL',
+				'decimal' => sprintf('NUMERIC(%d,%d)', $columnDefinition['precision'] ?? 10, $columnDefinition['scale'] ?? 0),
+				'boolean' => 'BOOLEAN',
+				'date' => 'DATE',
+				'datetime' => 'DATETIME',
+				'time' => 'TIME',
+				'timestamp' => 'TIMESTAMP',
+				'text', 'json', 'uuid' => 'TEXT',
+				'blob', 'binary' => 'BLOB',
+				'char' => "CHAR({$limit})",
+				// 'string', 'enum', 'set', and any unrecognized type
+				default => "VARCHAR({$limit})",
+			};
+		}
+
+		/**
+		 * SQL Server DDL type mapping. No UNSIGNED modifier; TINYINT is already
+		 * unsigned (0-255) by definition. TIMESTAMP is deliberately avoided even
+		 * for the ORM's 'timestamp' type — in T-SQL, TIMESTAMP names a rowversion
+		 * type, not a datetime, so DATETIME2 is used for both 'datetime' and
+		 * 'timestamp'. TEXT/BLOB use their MAX-length replacements, since TEXT/
+		 * IMAGE are deprecated.
+		 * @param array{type: string, limit: int|array<int,int>|null, unsigned: bool, precision: int|null, scale: int|null} $columnDefinition
+		 * @return string
+		 */
+		private function getSqlServerTempTableColumnType(array $columnDefinition): string {
+			$limit = is_int($columnDefinition['limit']) ? $columnDefinition['limit'] : 255;
+
+			return match ($columnDefinition['type']) {
+				'tinyinteger' => 'TINYINT',
+				'smallinteger', 'year' => 'SMALLINT',
+				'integer' => 'INT',
+				'biginteger' => 'BIGINT',
+				'float' => 'REAL',
+				'decimal' => sprintf('DECIMAL(%d,%d)', $columnDefinition['precision'] ?? 10, $columnDefinition['scale'] ?? 0),
+				'boolean' => 'BIT',
+				'date' => 'DATE',
+				'datetime', 'timestamp' => 'DATETIME2',
+				'time' => 'TIME',
+				'text', 'json' => 'NVARCHAR(MAX)',
+				'blob', 'binary' => 'VARBINARY(MAX)',
+				'uuid' => 'UNIQUEIDENTIFIER',
+				'char' => "CHAR({$limit})",
+				// 'string', 'enum', 'set', and any unrecognized type
+				default => "VARCHAR({$limit})",
+			};
+		}
+	}

--- a/packages/objectquel/src/DatabaseAdapter/DDLTypeMapper.php
+++ b/packages/objectquel/src/DatabaseAdapter/DDLTypeMapper.php
@@ -5,21 +5,14 @@
 	use Quellabs\ObjectQuel\Capabilities\PlatformCapabilitiesInterface;
 
 	/**
-	 * Renders engine-specific SQL DDL fragments for session-scoped temporary
-	 * tables, driven by a PlatformCapabilitiesInterface's reported facts.
+	 * Renders engine-specific SQL DDL for session-scoped temporary tables,
+	 * driven by a PlatformCapabilitiesInterface's reported facts. Unlike
+	 * TypeMapper (abstract @Column type → PHP type, engine-agnostic), this
+	 * maps to literal engine-specific SQL syntax.
 	 *
-	 * Unlike TypeMapper (which maps abstract @Column types to PHP types and is
-	 * engine-agnostic), this maps them to literal engine-specific SQL syntax —
-	 * e.g. no UNSIGNED modifier outside MySQL/MariaDB, no TINYINT/YEAR on
-	 * PostgreSQL or SQL Server, native BOOLEAN/UUID/BYTEA types on PostgreSQL
-	 * instead of TINYINT(1)/CHAR(36)/BLOB. PlatformCapabilitiesInterface itself
-	 * only reports facts (booleans, tokens, getDatabaseType()) and never builds
-	 * SQL text — this class is where those facts turn into actual SQL.
-	 *
-	 * Used only by TempTableExecutor. Identifier/alias quoting is a separate,
-	 * non-DDL concern (every SQL statement needs it, not just DDL) and lives in
-	 * SqlIdentifierQuoter instead — QuelToSQL, which never emits DDL, depends
-	 * on that class, not this one.
+	 * Used only by TempTableExecutor. Identifier/alias quoting lives in
+	 * SqlIdentifierQuoter instead, since it's needed by every SQL statement,
+	 * not just DDL — QuelToSQL depends on that class, not this one.
 	 */
 	class DDLTypeMapper {
 
@@ -37,16 +30,11 @@
 		}
 
 		/**
-		 * Returns the physical table name to use for a session-scoped temporary
-		 * table, given the logical base name.
-		 *
-		 * Every supported engine except SQL Server creates temporary tables by
-		 * name exactly as given, distinguished from permanent tables only by the
-		 * CREATE/DROP keyword (see getCreateTempTableKeyword()/getDropTempTableKeyword()).
-		 * SQL Server has no such keyword: a "local temporary table" is identified
-		 * purely by a leading '#' in its name. Callers must use the name this
-		 * method returns for every subsequent reference to the table (DDL, DML,
-		 * and any later SQL that reads from it) — not just the CREATE statement.
+		 * Returns the physical table name for a session-scoped temporary table.
+		 * SQL Server has no CREATE/DROP TEMPORARY keyword — a local temp table
+		 * is identified purely by a leading '#' in its name — so callers must
+		 * use this returned name everywhere the table is referenced, not just
+		 * in the CREATE statement.
 		 *
 		 * @param string $baseName Logical temp table name, e.g. 'tmp_range_abc123'
 		 * @return string The physical name to create and reference
@@ -56,14 +44,9 @@
 		}
 
 		/**
-		 * Returns the CREATE-statement keyword sequence for a session-scoped
-		 * temporary table, up to but not including the table name.
-		 *
-		 * Examples by engine:
-		 *   MySQL/MariaDB/PostgreSQL/SQLite → 'CREATE TEMPORARY TABLE'
-		 *   SQL Server                      → 'CREATE TABLE' (temp-ness comes from
-		 *                                      the '#' prefix in getTempTableName())
-		 *
+		 * Returns the CREATE-statement keyword sequence, up to but not including
+		 * the table name. SQL Server gets plain 'CREATE TABLE' — its temp-ness
+		 * comes from the '#' prefix in getTempTableName(), not a keyword.
 		 * @return string
 		 */
 		public function getCreateTempTableKeyword(): string {
@@ -71,17 +54,10 @@
 		}
 
 		/**
-		 * Returns the DROP-statement keyword sequence for a session-scoped
-		 * temporary table, up to but not including the table name.
-		 *
-		 * Only MySQL/MariaDB accept the TEMPORARY keyword in DROP TABLE; every
-		 * other engine rejects it there even though it's required (or, for SQL
-		 * Server, irrelevant) in CREATE.
-		 *
-		 * Examples by engine:
-		 *   MySQL/MariaDB                        → 'DROP TEMPORARY TABLE IF EXISTS'
-		 *   PostgreSQL/SQLite/SQL Server          → 'DROP TABLE IF EXISTS'
-		 *
+		 * Returns the DROP-statement keyword sequence, up to but not including
+		 * the table name. Only MySQL/MariaDB accept TEMPORARY in DROP TABLE;
+		 * every other engine rejects it there even though CREATE requires (or,
+		 * for SQL Server, ignores) it.
 		 * @return string
 		 */
 		public function getDropTempTableKeyword(): string {
@@ -140,8 +116,9 @@
 		}
 
 		/**
-		 * PostgreSQL DDL type mapping. No UNSIGNED modifier, no TINYINT/YEAR;
-		 * native BOOLEAN/UUID/BYTEA types replace MySQL's TINYINT(1)/CHAR(36)/BLOB.
+		 * PostgreSQL DDL type mapping: no UNSIGNED, no TINYINT/YEAR (SMALLINT
+		 * covers both — Postgres has no 1-byte integer type); native
+		 * BOOLEAN/UUID/BYTEA replace MySQL's TINYINT(1)/CHAR(36)/BLOB.
 		 * @param array{type: string, limit: int|array<int,int>|null, unsigned: bool, precision: int|null, scale: int|null} $columnDefinition
 		 * @return string
 		 */
@@ -149,7 +126,6 @@
 			$limit = is_int($columnDefinition['limit']) ? $columnDefinition['limit'] : 255;
 
 			return match ($columnDefinition['type']) {
-				// PostgreSQL has no 1-byte integer type; SMALLINT is the closest fit.
 				'tinyinteger', 'smallinteger', 'year' => 'SMALLINT',
 				'integer' => 'INTEGER',
 				'biginteger' => 'BIGINT',
@@ -172,8 +148,7 @@
 		/**
 		 * SQLite DDL type mapping. SQLite derives storage affinity from the type
 		 * name rather than enforcing a fixed type system, so this only needs to
-		 * avoid syntax SQLite doesn't parse (e.g. UNSIGNED) — it does not need a
-		 * distinct type name per case the way the other engines do.
+		 * avoid syntax it can't parse (e.g. UNSIGNED), not a distinct name per case.
 		 * @param array{type: string, limit: int|array<int,int>|null, unsigned: bool, precision: int|null, scale: int|null} $columnDefinition
 		 * @return string
 		 */
@@ -198,12 +173,11 @@
 		}
 
 		/**
-		 * SQL Server DDL type mapping. No UNSIGNED modifier; TINYINT is already
-		 * unsigned (0-255) by definition. TIMESTAMP is deliberately avoided even
-		 * for the ORM's 'timestamp' type — in T-SQL, TIMESTAMP names a rowversion
-		 * type, not a datetime, so DATETIME2 is used for both 'datetime' and
-		 * 'timestamp'. TEXT/BLOB use their MAX-length replacements, since TEXT/
-		 * IMAGE are deprecated.
+		 * SQL Server DDL type mapping. No UNSIGNED (TINYINT is already 0-255 by
+		 * definition). TIMESTAMP is deliberately never emitted — in T-SQL that
+		 * name means a rowversion, not a datetime — so DATETIME2 covers both
+		 * 'datetime' and 'timestamp'. TEXT/IMAGE are deprecated; their
+		 * MAX-length replacements are used instead.
 		 * @param array{type: string, limit: int|array<int,int>|null, unsigned: bool, precision: int|null, scale: int|null} $columnDefinition
 		 * @return string
 		 */

--- a/packages/objectquel/src/DatabaseAdapter/DDLTypeMapper.php
+++ b/packages/objectquel/src/DatabaseAdapter/DDLTypeMapper.php
@@ -47,6 +47,16 @@
 		 * Returns the CREATE-statement keyword sequence, up to but not including
 		 * the table name. SQL Server gets plain 'CREATE TABLE' — its temp-ness
 		 * comes from the '#' prefix in getTempTableName(), not a keyword.
+		 *
+		 * NOTE: this method's "every engine except sqlsrv" default and
+		 * getDropTempTableKeyword()'s "only mysql/mariadb" default point in
+		 * opposite directions. That's intentional, not drift: CREATE TEMPORARY
+		 * TABLE is accepted by every engine except SQL Server, while TEMPORARY
+		 * in DROP TABLE is accepted only by MySQL/MariaDB — the two statements
+		 * genuinely differ per engine, so mirroring one method's branch
+		 * structure onto the other would misrepresent real SQL syntax.
+		 * getDatabaseType() is a closed enumeration (see DatabaseAdapter), so
+		 * there is no unrecognised value for the two to disagree on in practice.
 		 * @return string
 		 */
 		public function getCreateTempTableKeyword(): string {
@@ -57,7 +67,8 @@
 		 * Returns the DROP-statement keyword sequence, up to but not including
 		 * the table name. Only MySQL/MariaDB accept TEMPORARY in DROP TABLE;
 		 * every other engine rejects it there even though CREATE requires (or,
-		 * for SQL Server, ignores) it.
+		 * for SQL Server, ignores) it. See the note on getCreateTempTableKeyword()
+		 * about why this method's default direction differs from that one.
 		 * @return string
 		 */
 		public function getDropTempTableKeyword(): string {
@@ -88,7 +99,7 @@
 		 * @return string
 		 */
 		private function getMysqlTempTableColumnType(array $columnDefinition): string {
-			$limit = is_int($columnDefinition['limit']) ? $columnDefinition['limit'] : 255;
+			$limit = is_int($columnDefinition['limit']) ? $columnDefinition['limit'] : (TypeMapper::getDefaultLimit($columnDefinition['type']) ?? 255);
 			$unsigned = $columnDefinition['unsigned'] ? ' UNSIGNED' : '';
 
 			return match ($columnDefinition['type']) {
@@ -123,7 +134,7 @@
 		 * @return string
 		 */
 		private function getPostgresTempTableColumnType(array $columnDefinition): string {
-			$limit = is_int($columnDefinition['limit']) ? $columnDefinition['limit'] : 255;
+			$limit = is_int($columnDefinition['limit']) ? $columnDefinition['limit'] : (TypeMapper::getDefaultLimit($columnDefinition['type']) ?? 255);
 
 			return match ($columnDefinition['type']) {
 				'tinyinteger', 'smallinteger', 'year' => 'SMALLINT',
@@ -153,7 +164,7 @@
 		 * @return string
 		 */
 		private function getSqliteTempTableColumnType(array $columnDefinition): string {
-			$limit = is_int($columnDefinition['limit']) ? $columnDefinition['limit'] : 255;
+			$limit = is_int($columnDefinition['limit']) ? $columnDefinition['limit'] : (TypeMapper::getDefaultLimit($columnDefinition['type']) ?? 255);
 
 			return match ($columnDefinition['type']) {
 				'tinyinteger', 'smallinteger', 'integer', 'biginteger', 'year' => 'INTEGER',
@@ -182,7 +193,7 @@
 		 * @return string
 		 */
 		private function getSqlServerTempTableColumnType(array $columnDefinition): string {
-			$limit = is_int($columnDefinition['limit']) ? $columnDefinition['limit'] : 255;
+			$limit = is_int($columnDefinition['limit']) ? $columnDefinition['limit'] : (TypeMapper::getDefaultLimit($columnDefinition['type']) ?? 255);
 
 			return match ($columnDefinition['type']) {
 				'tinyinteger' => 'TINYINT',

--- a/packages/objectquel/src/DatabaseAdapter/SqlIdentifierQuoter.php
+++ b/packages/objectquel/src/DatabaseAdapter/SqlIdentifierQuoter.php
@@ -1,0 +1,86 @@
+<?php
+
+	namespace Quellabs\ObjectQuel\DatabaseAdapter;
+
+	use Quellabs\ObjectQuel\Capabilities\PlatformCapabilitiesInterface;
+
+	/**
+	 * Quotes SQL identifiers and aliases for whichever engine a
+	 * PlatformCapabilitiesInterface describes.
+	 *
+	 * This is a general SQL-rendering concern, not a DDL one — every generated
+	 * statement needs identifiers quoted (SELECT, JOIN, INSERT, CREATE, all of
+	 * it), so this stays separate from DDLTypeMapper, which is specifically
+	 * about temporary-table DDL for TempTableExecutor. QuelToSQL (the QUEL→SQL
+	 * compiler, which never emits DDL) depends on this class, not on
+	 * DDLTypeMapper, for exactly that reason.
+	 *
+	 * Deliberately does not delegate to DatabaseAdapter::escapeIdentifier()
+	 * (used throughout the Persistence\* classes for INSERT/UPDATE/DELETE),
+	 * even though both ultimately do "wrap in this engine's quote characters".
+	 * escapeIdentifier() delegates to the connected CakePHP driver's own
+	 * quoter, which is unsafe for two things this class is specifically used
+	 * for:
+	 *   - Alias quoting: the driver's quoter splits any '.' into a qualified
+	 *     `x`.`id` reference (it's built for real table.column identifiers).
+	 *     QuelToSQL deliberately builds single-token aliases containing a
+	 *     literal '.' (e.g. 'x.id'); splitting them produces invalid SQL in
+	 *     alias position. See quoteIdentifier().
+	 *   - SQL Server temp table names: the driver's quoter's regexes all
+	 *     require the identifier to start with a word character, so a
+	 *     '#'-prefixed local temp table name (see DDLTypeMapper::getTempTableName())
+	 *     matches none of them and falls through to being returned completely
+	 *     UNQUOTED — verified directly against Cake\Database\IdentifierQuoter:
+	 *     quoteIdentifier('#tmp_x') returns '#tmp_x', not '[#tmp_x]'.
+	 * Both failure modes are silent (no exception, just wrong/unquoted SQL),
+	 * which is why this class always does the simple, predictable wrap rather
+	 * than reusing the driver's smarter-but-unsafe-for-us quoter. It's also
+	 * the only option for QuelToSQL, which is deliberately never given a live
+	 * DatabaseAdapter/connection (see its own docblock) and so has no way to
+	 * reach escapeIdentifier() regardless.
+	 */
+	class SqlIdentifierQuoter {
+
+		/**
+		 * @var PlatformCapabilitiesInterface
+		 */
+		private PlatformCapabilitiesInterface $platform;
+
+		/**
+		 * SqlIdentifierQuoter constructor
+		 * @param PlatformCapabilitiesInterface $platform
+		 */
+		public function __construct(PlatformCapabilitiesInterface $platform) {
+			$this->platform = $platform;
+		}
+
+		/**
+		 * Quotes a table, column, or alias identifier for safe inclusion in
+		 * generated SQL.
+		 *
+		 * Wraps the identifier as a single opaque token in the connected engine's
+		 * quote characters — MySQL/MariaDB/SQLite use backticks, PostgreSQL uses
+		 * double quotes, SQL Server uses square brackets. Always treats the input
+		 * as one literal token and never splits on '.' into a qualified
+		 * table.column reference.
+		 *
+		 * That "never split" guarantee is load-bearing for QuelToSQL's alias
+		 * positions: it deliberately builds alias names containing a literal '.'
+		 * (e.g. 'x.id', so a subquery's flattened columns can be looked up by the
+		 * outer range+property they came from) that must survive quoting as one
+		 * token — a qualifier-aware quoter would instead treat 'x.id' as a
+		 * qualified reference and emit the invalid `x`.`id` in alias position.
+		 * Real table/column names never contain '.', so the same guarantee is a
+		 * no-op (and therefore harmless) when this is used for those instead.
+		 *
+		 * @param string $identifier Unquoted identifier or alias text, which may itself contain '.'
+		 * @return string The identifier wrapped in the engine's quote characters
+		 */
+		public function quoteIdentifier(string $identifier): string {
+			return match ($this->platform->getDatabaseType()) {
+				'pgsql', 'sqlite' => '"' . str_replace('"', '""', $identifier) . '"',
+				'sqlsrv' => '[' . str_replace(']', ']]', $identifier) . ']',
+				default => '`' . str_replace('`', '``', $identifier) . '`',
+			};
+		}
+	}

--- a/packages/objectquel/src/DatabaseAdapter/SqlIdentifierQuoter.php
+++ b/packages/objectquel/src/DatabaseAdapter/SqlIdentifierQuoter.php
@@ -32,7 +32,15 @@
 	 *     matches none of them and falls through to being returned completely
 	 *     UNQUOTED — verified directly against Cake\Database\IdentifierQuoter:
 	 *     quoteIdentifier('#tmp_x') returns '#tmp_x', not '[#tmp_x]'.
-	 * Both failure modes are silent (no exception, just wrong/unquoted SQL),
+	 *   - SQLite double-quote fallback: SQLite silently reinterprets an
+	 *     unresolvable double-quoted token as a string literal instead of
+	 *     raising an error (kept for compatibility with older code that used
+	 *     double quotes for string literals); backtick-quoted tokens have no
+	 *     such fallback. CakePHP's SQLite driver uses double quotes, so
+	 *     escapeIdentifier() carries this risk on SQLite; this class uses
+	 *     backticks for SQLite instead (grouped with MySQL/MariaDB below).
+	 * All three failure modes above are silent (no exception, just wrong or
+	 * unquoted SQL, or SQL that quietly changes meaning),
 	 * which is why this class always does the simple, predictable wrap rather
 	 * than reusing the driver's smarter-but-unsafe-for-us quoter. It's also
 	 * the only option for QuelToSQL, which is deliberately never given a live
@@ -78,8 +86,9 @@
 		 */
 		public function quoteIdentifier(string $identifier): string {
 			return match ($this->platform->getDatabaseType()) {
-				'pgsql', 'sqlite' => '"' . str_replace('"', '""', $identifier) . '"',
+				'pgsql' => '"' . str_replace('"', '""', $identifier) . '"',
 				'sqlsrv' => '[' . str_replace(']', ']]', $identifier) . ']',
+				// mysql/mariadb/sqlite: see the SQLite double-quote note above.
 				default => '`' . str_replace('`', '``', $identifier) . '`',
 			};
 		}

--- a/packages/objectquel/src/Execution/Executors/TempTableExecutor.php
+++ b/packages/objectquel/src/Execution/Executors/TempTableExecutor.php
@@ -2,7 +2,10 @@
 	
 	namespace Quellabs\ObjectQuel\Execution\Executors;
 	
+	use Quellabs\ObjectQuel\Capabilities\PlatformCapabilitiesInterface;
 	use Quellabs\ObjectQuel\DatabaseAdapter\DatabaseAdapter;
+	use Quellabs\ObjectQuel\DatabaseAdapter\DDLTypeMapper;
+	use Quellabs\ObjectQuel\DatabaseAdapter\SqlIdentifierQuoter;
 	use Quellabs\ObjectQuel\EntityStore;
 	use Quellabs\ObjectQuel\Planner\TempTableStage;
 	use Quellabs\ObjectQuel\ObjectQuel\Ast\AstIdentifier;
@@ -17,10 +20,12 @@
 	 *      handles JSON and database stages correctly via the existing flow).
 	 *   2. Inspecting the first result row to infer a column schema, or falling back
 	 *      to the inner query's projection list when the result is empty.
-	 *   3. Creating a MySQL temporary table with that schema.
+	 *   3. Creating a session-scoped temporary table with that schema, using DDL
+	 *      appropriate to the connected engine (see DDLTypeMapper).
 	 *   4. Inserting all result rows in batches.
-	 *   5. Mutating the AstRangeDatabase: setQuery(null) + setTableName(), so that
-	 *      QuelToSQL will reference the temp table as a plain table.
+	 *   5. Mutating the AstRangeDatabase via setTableName() with the resolved
+	 *      physical table name, so QuelToSQL will reference the temp table as a
+	 *      plain table.
 	 *   6. Registering the temp table name for cleanup after the outer query completes.
 	 *
 	 * Cleanup must be called explicitly by the orchestrating code (PlanExecutor)
@@ -43,8 +48,9 @@
 	 *   (function calls, computed expressions, literals) fall back to VARCHAR(255).
 	 *
 	 * Batch size:
-	 *   Rows are inserted in batches of INSERT_BATCH_SIZE to avoid hitting MySQL's
-	 *   max_allowed_packet limit on very large result sets.
+	 *   Rows are inserted in batches of INSERT_BATCH_SIZE to avoid hitting
+	 *   per-statement/packet size limits (e.g. MySQL's max_allowed_packet) on
+	 *   very large result sets.
 	 */
 	class TempTableExecutor {
 		
@@ -67,7 +73,22 @@
 		private EntityStore $entityStore;
 
 		/**
-		 * Names of temporary tables created during this execution, registered for cleanup
+		 * Renders temp table DDL (CREATE/DROP keywords, physical name, column
+		 * types) correctly for whichever engine is connected.
+		 * @var DDLTypeMapper
+		 */
+		private DDLTypeMapper $ddlTypeMapper;
+
+		/**
+		 * Quotes table/column identifiers correctly for whichever engine is connected.
+		 * @var SqlIdentifierQuoter
+		 */
+		private SqlIdentifierQuoter $identifierQuoter;
+
+		/**
+		 * Names of temporary tables created during this execution, registered for cleanup.
+		 * These are physical names (see DDLTypeMapper::getTempTableName()),
+		 * not the logical range table name.
 		 * @var string[]
 		 */
 		private array $createdTables = [];
@@ -76,10 +97,13 @@
 		 * TempTableExecutor constructor
 		 * @param DatabaseAdapter $connection
 		 * @param EntityStore $entityStore
+		 * @param PlatformCapabilitiesInterface $platform
 		 */
-		public function __construct(DatabaseAdapter $connection, EntityStore $entityStore) {
+		public function __construct(DatabaseAdapter $connection, EntityStore $entityStore, PlatformCapabilitiesInterface $platform) {
 			$this->connection = $connection;
 			$this->entityStore = $entityStore;
+			$this->ddlTypeMapper = new DDLTypeMapper($platform);
+			$this->identifierQuoter = new SqlIdentifierQuoter($platform);
 		}
 		
 		/**
@@ -97,8 +121,14 @@
 		 */
 		public function execute(TempTableStage $stage, callable $runner): void {
 			$range = $stage->getRange();
-			$tableName = $range->getTableName();
 			$innerQuery = $stage->getQuery();
+
+			// Resolve the physical table name for the connected engine (SQL Server
+			// prefixes with '#'; every other engine uses the logical name as-is)
+			// and store it back on the range so downstream SQL generation
+			// (QuelToSQL) references the same physical table this method creates.
+			$tableName = $this->ddlTypeMapper->getTempTableName($range->getTableName());
+			$range->setTableName($tableName);
 			
 			// Execute the inner query through the full pipeline.
 			// This handles JSON stages, sub-decomposition, etc. transparently.
@@ -139,13 +169,14 @@
 		 * Must be called in a finally block after the outer query completes,
 		 * whether execution succeeded or failed.
 		 * Errors during cleanup are silently swallowed to avoid masking the real result:
-		 * MySQL will drop session-scoped temporary tables automatically when the
-		 * connection closes anyway.
+		 * every supported engine drops session-scoped temporary tables automatically
+		 * when the connection closes anyway.
 		 */
 		public function cleanup(): void {
 			foreach ($this->createdTables as $tableName) {
 				try {
-					$this->connection->execute("DROP TEMPORARY TABLE IF EXISTS `{$tableName}`");
+					$quotedName = $this->identifierQuoter->quoteIdentifier($tableName);
+					$this->connection->execute("{$this->ddlTypeMapper->getDropTempTableKeyword()} {$quotedName}");
 				} catch (\Throwable) {
 					// Silently ignore cleanup failures — see docblock above
 				}
@@ -220,40 +251,7 @@
 				return 'VARCHAR(255)';
 			}
 
-			return $this->sqlTypeFromColumnDefinition($columnDefinition);
-		}
-
-		/**
-		 * Maps a declared @Column definition to a MySQL DDL type fragment.
-		 * @param array{type: string, limit: int|array<int,int>|null, unsigned: bool, precision: int|null, scale: int|null} $columnDefinition
-		 * @return string
-		 */
-		private function sqlTypeFromColumnDefinition(array $columnDefinition): string {
-			$limit = is_int($columnDefinition['limit']) ? $columnDefinition['limit'] : 255;
-			$unsigned = $columnDefinition['unsigned'] ? ' UNSIGNED' : '';
-
-			return match ($columnDefinition['type']) {
-				'tinyinteger' => "TINYINT{$unsigned}",
-				'smallinteger' => "SMALLINT{$unsigned}",
-				'integer' => "INT{$unsigned}",
-				'biginteger' => "BIGINT{$unsigned}",
-				'float' => "FLOAT{$unsigned}",
-				'decimal' => sprintf('DECIMAL(%d,%d)%s', $columnDefinition['precision'] ?? 10, $columnDefinition['scale'] ?? 0, $unsigned),
-				'boolean' => 'TINYINT(1)',
-				'date' => 'DATE',
-				'datetime' => 'DATETIME',
-				'time' => 'TIME',
-				'timestamp' => 'TIMESTAMP',
-				'text' => 'TEXT',
-				'blob' => 'BLOB',
-				'binary' => "VARBINARY({$limit})",
-				'json' => 'JSON',
-				'uuid' => 'CHAR(36)',
-				'year' => 'YEAR',
-				'char' => "CHAR({$limit})",
-				// 'string', 'enum', 'set', and any unrecognized type
-				default => "VARCHAR({$limit})",
-			};
+			return $this->ddlTypeMapper->getTempTableColumnType($columnDefinition);
 		}
 
 		/**
@@ -268,13 +266,14 @@
 		 */
 		private function createTable(string $tableName, array $columns, array $columnTypes): void {
 			$columnDefs = array_map(
-				fn(string $col) => "`{$col}` " . ($columnTypes[$col] ?? 'VARCHAR(255)') . " NULL",
+				fn(string $col) => $this->identifierQuoter->quoteIdentifier($col) . ' ' . ($columnTypes[$col] ?? 'VARCHAR(255)') . " NULL",
 				$columns
 			);
-			
+
 			$sql = sprintf(
-				"CREATE TEMPORARY TABLE `%s` (%s)",
-				$tableName,
+				"%s %s (%s)",
+				$this->ddlTypeMapper->getCreateTempTableKeyword(),
+				$this->identifierQuoter->quoteIdentifier($tableName),
 				implode(', ', $columnDefs)
 			);
 			
@@ -292,19 +291,21 @@
 		
 		/**
 		 * Inserts rows into the temporary table in batches.
-		 * Batching avoids hitting MySQL's max_allowed_packet limit on large result sets.
+		 * Batching avoids hitting per-statement/packet size limits (e.g. MySQL's
+		 * max_allowed_packet) on large result sets.
 		 * @param string $tableName
 		 * @param string[] $columns
 		 * @param list<array<string, bool|float|int|string|null>> $rows
 		 * @throws QuelException
 		 */
 		private function insertRows(string $tableName, array $columns, array $rows): void {
-			$columnList = implode(', ', array_map(fn($c) => "`{$c}`", $columns));
+			$columnList = implode(', ', array_map(fn($c) => $this->identifierQuoter->quoteIdentifier($c), $columns));
+			$quotedTableName = $this->identifierQuoter->quoteIdentifier($tableName);
 			$placeholderRow = '(' . implode(', ', array_fill(0, count($columns), '?')) . ')';
-			
+
 			foreach (array_chunk($rows, self::INSERT_BATCH_SIZE) as $batch) {
 				$placeholders = implode(', ', array_fill(0, count($batch), $placeholderRow));
-				$sql = "INSERT INTO `{$tableName}` ({$columnList}) VALUES {$placeholders}";
+				$sql = "INSERT INTO {$quotedTableName} ({$columnList}) VALUES {$placeholders}";
 				
 				// Flatten the batch of rows into a single parameter array.
 				// Missing keys are treated as null; objects are cast to string defensively.

--- a/packages/objectquel/src/Execution/Helpers/BuildSqlFragments.php
+++ b/packages/objectquel/src/Execution/Helpers/BuildSqlFragments.php
@@ -2,6 +2,9 @@
 	
 	namespace Quellabs\ObjectQuel\Execution\Helpers;
 	
+	use Quellabs\ObjectQuel\Capabilities\NullPlatformCapabilities;
+	use Quellabs\ObjectQuel\Capabilities\PlatformCapabilitiesInterface;
+	use Quellabs\ObjectQuel\DatabaseAdapter\SqlIdentifierQuoter;
 	use Quellabs\ObjectQuel\EntityStore;
 	use Quellabs\ObjectQuel\Exception\EntityResolutionException;
 	use Quellabs\ObjectQuel\Execution\SqlGeneratorInterface;
@@ -34,7 +37,10 @@
 		
 		/** @var string|null When set, column aliases in buildEntityColumns use this name instead of the inner range name */
 		private ?string $subqueryAliasRangeName;
-		
+
+		/** @var SqlIdentifierQuoter Quotes table/column identifiers correctly for the connected engine */
+		private SqlIdentifierQuoter $identifierQuoter;
+
 		/**
 		 * Constructor - initializes the SQL builder helper with required dependencies
 		 * @param EntityStore $entityStore Entity metadata store
@@ -42,15 +48,18 @@
 		 * @param string|null $subqueryAliasRangeName When set, buildEntityColumns() aliases columns
 		 *        using this name instead of the inner range name, so derived table columns match
 		 *        what the outer query expects (e.g. "x.id" instead of "y.id")
+		 * @param PlatformCapabilitiesInterface $platform Database engine capability descriptor
 		 */
 		public function __construct(
 			EntityStore           $entityStore,
 			SqlGeneratorInterface $mainVisitor,
-			?string               $subqueryAliasRangeName = null
+			?string               $subqueryAliasRangeName = null,
+			PlatformCapabilitiesInterface $platform = new NullPlatformCapabilities()
 		) {
 			$this->entityStore = $entityStore;
 			$this->mainVisitor = $mainVisitor;
 			$this->subqueryAliasRangeName = $subqueryAliasRangeName;
+			$this->identifierQuoter = new SqlIdentifierQuoter($platform);
 		}
 		
 		/**
@@ -113,7 +122,9 @@
 			
 			// Build aliased column selections for each property
 			foreach ($metadata->columnMap as $item => $value) {
-				$result[] = "`{$rangeName}`.`{$value}` as `{$aliasRangeName}.{$item}`";
+				$columnRef = $this->identifierQuoter->quoteIdentifier($rangeName) . '.' . $this->identifierQuoter->quoteIdentifier($value);
+				$alias = $this->identifierQuoter->quoteIdentifier("{$aliasRangeName}.{$item}");
+				$result[] = "{$columnRef} as {$alias}";
 			}
 			
 			return implode(",", $result);

--- a/packages/objectquel/src/Execution/Helpers/ProcessAggregate.php
+++ b/packages/objectquel/src/Execution/Helpers/ProcessAggregate.php
@@ -2,6 +2,9 @@
 	
 	namespace Quellabs\ObjectQuel\Execution\Helpers;
 	
+	use Quellabs\ObjectQuel\Capabilities\NullPlatformCapabilities;
+	use Quellabs\ObjectQuel\Capabilities\PlatformCapabilitiesInterface;
+	use Quellabs\ObjectQuel\DatabaseAdapter\SqlIdentifierQuoter;
 	use Quellabs\ObjectQuel\EntityStore;
 	use Quellabs\ObjectQuel\Exception\EntityResolutionException;
 	use Quellabs\ObjectQuel\Execution\Visitors\BuildSqlFromAst;
@@ -52,24 +55,30 @@
 		
 		/** @var BuildSqlFromAst Converts AST nodes to their SQL string representations */
 		private BuildSqlFromAst $convertToString;
-		
+
+		/** @var SqlIdentifierQuoter Quotes table/column identifiers correctly for the connected engine */
+		private SqlIdentifierQuoter $identifierQuoter;
+
 		/**
 		 * Initializes the aggregate handler with required dependencies.
 		 * @param EntityStore $entityStore Maps entity names to table names and provides schema metadata
 		 * @param string $partOfQuery Current SQL clause context (SELECT, WHERE, etc.) for output formatting
 		 * @param BuildSqlFragments $sqlBuilder Helper for building SQL components like joins and conditions
 		 * @param BuildSqlFromAst $convertToString Converts AST expressions to SQL strings
+		 * @param PlatformCapabilitiesInterface $platform Database engine capability descriptor
 		 */
 		public function __construct(
 			EntityStore $entityStore,
 			string $partOfQuery,
 			BuildSqlFragments $sqlBuilder,
 			BuildSqlFromAst $convertToString,
+			PlatformCapabilitiesInterface $platform = new NullPlatformCapabilities(),
 		) {
 			$this->entityStore = $entityStore;
 			$this->partOfQuery = $partOfQuery;
 			$this->sqlBuilder = $sqlBuilder;
 			$this->convertToString = $convertToString;
+			$this->identifierQuoter = new SqlIdentifierQuoter($platform);
 		}
 		
 		// ============================================================================
@@ -639,7 +648,7 @@
 			$metadata = $this->entityStore->getMetadata($mainRange->getEntityName());
 			
 			// Convert to SQL
-			$sql = "`{$metadata->tableName}` {$mainRange->getName()}";
+			$sql = $this->identifierQuoter->quoteIdentifier($metadata->tableName) . ' ' . $this->identifierQuoter->quoteIdentifier($mainRange->getName());
 			
 			// Add JOIN clauses for each related range
 			foreach ($joinRanges as $range) {
@@ -661,7 +670,7 @@
 				$joinType = $range->isRequired() ? "INNER" : "LEFT";
 				
 				// Add it to the query
-				$sql .= " {$joinType} JOIN `{$metadata->tableName}` {$range->getName()} ON {$joinCondition}";
+				$sql .= " {$joinType} JOIN " . $this->identifierQuoter->quoteIdentifier($metadata->tableName) . ' ' . $this->identifierQuoter->quoteIdentifier($range->getName()) . " ON {$joinCondition}";
 			}
 			
 			return $sql;

--- a/packages/objectquel/src/Execution/Helpers/ProcessExpression.php
+++ b/packages/objectquel/src/Execution/Helpers/ProcessExpression.php
@@ -27,6 +27,7 @@
 	use Quellabs\ObjectQuel\Capabilities\FulltextIndexStyle;
 	use Quellabs\ObjectQuel\Capabilities\NullPlatformCapabilities;
 	use Quellabs\ObjectQuel\Capabilities\PlatformCapabilitiesInterface;
+	use Quellabs\ObjectQuel\DatabaseAdapter\SqlIdentifierQuoter;
 	use Quellabs\ObjectQuel\ObjectQuel\Ast\NodeBinary;
 	use Quellabs\ObjectQuel\ObjectQuel\AstInterface;
 	use Quellabs\ObjectQuel\ObjectQuel\AstVisitorInterface;
@@ -92,7 +93,10 @@
 		
 		/** @var PlatformCapabilitiesInterface Describes what the connected database engine supports */
 		private PlatformCapabilitiesInterface $platform;
-		
+
+		/** @var SqlIdentifierQuoter Quotes table/column identifiers correctly for the connected engine */
+		private SqlIdentifierQuoter $identifierQuoter;
+
 		/**
 		 * Constructor - Initialize the expression handler with required dependencies
 		 * @param EntityStore $entityStore EntityStore holds entity metadata
@@ -113,6 +117,7 @@
 			$this->parameters = &$parameters;
 			$this->mainVisitor = $mainVisitor;
 			$this->platform = $platform;
+			$this->identifierQuoter = new SqlIdentifierQuoter($platform);
 		}
 		
 		/**
@@ -651,7 +656,7 @@
 			$propertyName = $nextNode->getName();
 			
 			if (empty($entityName)) {
-				return "{$rangeName}.`{$rangeName}.{$propertyName}`";
+				return "{$rangeName}." . $this->identifierQuoter->quoteIdentifier("{$rangeName}.{$propertyName}");
 			}
 			
 			// When the chain contains a JSON property, defer to the dedicated JSON
@@ -747,7 +752,7 @@
 			
 			// Column aliases in derived tables are stored as "rangeName.property" (e.g. "x.id"),
 			// so reference them with the range prefix to match the subquery's SELECT aliases.
-			return "`{$rangeName}`.`{$rangeName}.{$columnName}`";
+			return $this->identifierQuoter->quoteIdentifier($rangeName) . '.' . $this->identifierQuoter->quoteIdentifier("{$rangeName}.{$columnName}");
 		}
 		
 		/**
@@ -801,7 +806,7 @@
 			}
 			
 			// Return fully qualified column name
-			return "`{$rangeName}`.`{$metadata->columnMap[$property]}`";
+			return $this->identifierQuoter->quoteIdentifier($rangeName) . '.' . $this->identifierQuoter->quoteIdentifier($metadata->columnMap[$property]);
 		}
 		
 		/**
@@ -1105,31 +1110,36 @@
 			}
 			
 			// Build the JSON path expression and emit dialect-specific SQL.
+			// Every branch quotes the column reference via identifierQuoter rather
+			// than a hardcoded quote character, so quoting stays correct even if
+			// SqlIdentifierQuoter's per-engine choice ever changes.
+			$quotedColumn = $this->identifierQuoter->quoteIdentifier($rangeName) . '.' . $this->identifierQuoter->quoteIdentifier($columnName);
+
 			return match ($this->platform->getJsonExtractionStyle()) {
-				JsonExtractionStyle::HashDoubleArrow => (function () use ($rangeName, $columnName, $pathSegments) {
+				JsonExtractionStyle::HashDoubleArrow => (function () use ($quotedColumn, $pathSegments) {
 					// PostgreSQL: col #>> '{segment1,segment2,...}'
 					$pgPath = implode(',', $pathSegments);
-					return "\"{$rangeName}\".\"{$columnName}\" #>> '{" . $pgPath . "}'";
+					return "{$quotedColumn} #>> '{" . $pgPath . "}'";
 				})(),
-				
-				JsonExtractionStyle::JsonValue => (function () use ($rangeName, $columnName, $pathSegments) {
-					// SQL:2016 JSON_VALUE — MariaDB 10.9+. (SQLite has no
-					// JSON_VALUE() function at any version — see ArrowOperator.)
+
+				JsonExtractionStyle::JsonValue => (function () use ($quotedColumn, $pathSegments) {
+					// SQL:2016 JSON_VALUE — MariaDB 10.9+ and SQL Server. (SQLite has
+					// no JSON_VALUE() function at any version — see ArrowOperator.)
 					$jsonPath = '$.' . implode('.', $pathSegments);
-					return "JSON_VALUE(`{$rangeName}`.`{$columnName}`, '{$jsonPath}')";
+					return "JSON_VALUE({$quotedColumn}, '{$jsonPath}')";
 				})(),
-				
-				JsonExtractionStyle::ArrowOperator => (function () use ($rangeName, $columnName, $pathSegments) {
+
+				JsonExtractionStyle::ArrowOperator => (function () use ($quotedColumn, $pathSegments) {
 					// SQLite 3.38+: col ->> '$.a.b' — SQLite's equivalent of
 					// JSON_VALUE(); it unwraps the result to a plain SQL scalar.
 					$jsonPath = '$.' . implode('.', $pathSegments);
-					return "\"{$rangeName}\".\"{$columnName}\" ->> '{$jsonPath}'";
+					return "{$quotedColumn} ->> '{$jsonPath}'";
 				})(),
-				
+
 				// Default: MySQL/MariaDB JSON_UNQUOTE(JSON_EXTRACT(...))
-				default => (function () use ($rangeName, $columnName, $pathSegments) {
+				default => (function () use ($quotedColumn, $pathSegments) {
 					$jsonPath = '$.' . implode('.', $pathSegments);
-					return "JSON_UNQUOTE(JSON_EXTRACT(`{$rangeName}`.`{$columnName}`, '{$jsonPath}'))";
+					return "JSON_UNQUOTE(JSON_EXTRACT({$quotedColumn}, '{$jsonPath}'))";
 				})(),
 			};
 		}

--- a/packages/objectquel/src/Execution/PlanExecutor.php
+++ b/packages/objectquel/src/Execution/PlanExecutor.php
@@ -81,7 +81,8 @@
 			$this->constantExecutor = new ConstantQueryExecutor();
 			$this->tempTableExecutor = new TempTableExecutor(
 				$queryExecutor->getConnection(),
-				$queryExecutor->getEntityManager()->getEntityStore()
+				$queryExecutor->getEntityManager()->getEntityStore(),
+				$queryExecutor->getEntityManager()->getUnitOfWork()->getPlatformCapabilities()
 			);
 		}
 		

--- a/packages/objectquel/src/Execution/Visitors/BuildSqlFromAst.php
+++ b/packages/objectquel/src/Execution/Visitors/BuildSqlFromAst.php
@@ -54,6 +54,7 @@
 	use Quellabs\ObjectQuel\ObjectQuel\AstInterface;
 	use Quellabs\ObjectQuel\Capabilities\PlatformCapabilitiesInterface;
 	use Quellabs\ObjectQuel\Capabilities\NullPlatformCapabilities;
+	use Quellabs\ObjectQuel\DatabaseAdapter\CastTypeMapper;
 	use Quellabs\ObjectQuel\ObjectQuel\Ast\AstCast;
 	use Quellabs\ObjectQuel\ObjectQuel\AstVisitorInterface;
 	
@@ -94,7 +95,10 @@
 
 		/** @var PlatformCapabilitiesInterface Database engine capability descriptor */
 		private PlatformCapabilitiesInterface $platform;
-		
+
+		/** @var CastTypeMapper Resolves QUEL cast types to SQL type tokens for the connected engine */
+		private CastTypeMapper $castTypeMapper;
+
 		/**
 		 * Initialize the SQL converter with required dependencies
 		 * @param EntityStore $store Entity storage containing schema and metadata
@@ -119,7 +123,8 @@
 			$this->parameters = &$parameters; // Use reference to allow parameter modification
 			$this->partOfQuery = $partOfQuery;
 			$this->platform = $platform;
-			
+			$this->castTypeMapper = new CastTypeMapper($platform);
+
 			// Initialize helper classes with proper dependencies and references
 			$this->sqlFragmentBuilder = new BuildSqlFragments($this->entityStore, $this, $subqueryAliasRangeName);
 			$this->typeInference = new ResolveType($this->entityStore);
@@ -332,13 +337,10 @@
 		/**
 		 * Process a cast expression node.
 		 *
-		 * Emits either:
-		 *   CAST(col AS TYPE)   for MySQL, MariaDB, SQLite, SQL Server
-		 *   col::TYPE           for PostgreSQL (CastStyle::DoubleColon)
-		 *
-		 * The SQL type token (e.g. SIGNED, DOUBLE, TEXT) is resolved from
-		 * PlatformCapabilitiesInterface::getSupportedCastTypes() using the
-		 * canonical QUEL cast type stored on the node (e.g. int, float, string).
+		 * Emits standard CAST(col AS TYPE), supported by every engine ObjectQuel
+		 * targets. The SQL type token (e.g. SIGNED, DOUBLE, TEXT) is resolved from
+		 * CastTypeMapper::getSupportedCastTypes() using the canonical QUEL cast
+		 * type stored on the node (e.g. int, float, string).
 		 *
 		 * @param AstCast $ast The cast node to process
 		 */
@@ -353,7 +355,7 @@
 			// Resolve the SQL type token for the target engine.
 			// The semantic analyser has already verified that this cast type is
 			// supported, so the key is guaranteed to exist here.
-			$supportedTypes = $this->platform->getSupportedCastTypes();
+			$supportedTypes = $this->castTypeMapper->getSupportedCastTypes();
 			$sqlType = $supportedTypes[$ast->getCastType()] ?? strtoupper($ast->getCastType());
 
 			// Generate the SQL fragment for the inner expression

--- a/packages/objectquel/src/Execution/Visitors/BuildSqlFromAst.php
+++ b/packages/objectquel/src/Execution/Visitors/BuildSqlFromAst.php
@@ -126,9 +126,9 @@
 			$this->castTypeMapper = new CastTypeMapper($platform);
 
 			// Initialize helper classes with proper dependencies and references
-			$this->sqlFragmentBuilder = new BuildSqlFragments($this->entityStore, $this, $subqueryAliasRangeName);
+			$this->sqlFragmentBuilder = new BuildSqlFragments($this->entityStore, $this, $subqueryAliasRangeName, $this->platform);
 			$this->typeInference = new ResolveType($this->entityStore);
-			$this->aggregateHandler = new ProcessAggregate($this->entityStore, $this->partOfQuery, $this->sqlFragmentBuilder, $this);
+			$this->aggregateHandler = new ProcessAggregate($this->entityStore, $this->partOfQuery, $this->sqlFragmentBuilder, $this, $this->platform);
 			$this->expressionHandler = new ProcessExpression($this->entityStore, $this->typeInference, $this->parameters, $this, $this->platform);
 		}
 		

--- a/packages/objectquel/src/ObjectQuel/Ast/AstCast.php
+++ b/packages/objectquel/src/ObjectQuel/Ast/AstCast.php
@@ -21,8 +21,8 @@
 	 * performs the conversion. Use isPhpOnlyCast() to distinguish between the two.
 	 *
 	 * The exact SQL type token emitted depends on the connected engine and is
-	 * resolved by PlatformCapabilitiesInterface::getSupportedCastTypes() at
-	 * SQL-generation time. The cast type stored here is always the canonical
+	 * resolved by CastTypeMapper::getSupportedCastTypes() at SQL-generation
+	 * time. The cast type stored here is always the canonical
 	 * QUEL keyword (e.g. 'int', 'float', 'string', 'decimal'), never the
 	 * engine-specific SQL token.
 	 *

--- a/packages/objectquel/src/ObjectQuel/QuelToSQL.php
+++ b/packages/objectquel/src/ObjectQuel/QuelToSQL.php
@@ -83,6 +83,34 @@
 		protected function getUnique(AstRetrieve $retrieve): string {
 			return $retrieve->isUnique() ? "DISTINCT " : "";
 		}
+
+		/**
+		 * Appends " as <quoted-alias>" to a SQL expression. The expression may be
+		 * a quoted table identifier, a "(subquery)" fragment, or a column
+		 * expression — this is the "X AS alias" shape reused throughout
+		 * FROM/JOIN/column-list generation, differing only in what X is.
+		 * @param string $expression Already-quoted/complete SQL to alias
+		 * @param string $alias Unquoted alias name
+		 * @return string
+		 */
+		private function quoteAsAlias(string $expression, string $alias): string {
+			return "{$expression} as " . $this->identifierQuoter->quoteIdentifier($alias);
+		}
+
+		/**
+		 * Builds a single "<JOIN_TYPE> JOIN <table> as <alias> ON <condition>"
+		 * clause. $tableExpression is already-quoted SQL (a quoted table
+		 * identifier or a "(subquery)" fragment) — this only assembles the
+		 * shared JOIN/alias/ON structure around it.
+		 * @param string $joinType "INNER" or "LEFT"
+		 * @param string $tableExpression Already-quoted/complete SQL for the joined table
+		 * @param string $rangeName Unquoted alias name for the joined table
+		 * @param string $joinCondition SQL for the ON condition
+		 * @return string
+		 */
+		private function buildJoinClause(string $joinType, string $tableExpression, string $rangeName, string $joinCondition): string {
+			return "{$joinType} JOIN " . $this->quoteAsAlias($tableExpression, $rangeName) . " ON {$joinCondition}";
+		}
 		
 		/**
 		 * Returns true if the identifier is an entity, false if not
@@ -128,7 +156,7 @@
 						// Add the alias to the SQL result. $aliasName may itself contain a
 						// literal '.' (see outerRangeName handling above); quoteIdentifier()
 						// never splits on '.', so it survives quoting as a single token.
-						$sqlResult .= " as " . $this->identifierQuoter->quoteIdentifier($aliasName);
+						$sqlResult = $this->quoteAsAlias($sqlResult, $aliasName);
 					}
 					
 					// Add the SQL result to the result array
@@ -184,13 +212,13 @@
 				// Regular ranges reference a physical table looked up from the entity store.
 				if ($range instanceof AstRangeDatabaseSubquery) {
 					$subSQL = $this->convertToSQL($range->getQuery(), $rangeName);
-					$tableNames[] = "({$subSQL}) as " . $this->identifierQuoter->quoteIdentifier($rangeName);
+					$tableNames[] = $this->quoteAsAlias("({$subSQL})", $rangeName);
 				} else {
 					// Get the metadata for the entity.
 					$metadata = $this->entityStore->getMetadata($range->getEntityName());
 
 					// Add the table name and alias to the list for the FROM clause.
-					$tableNames[] = $this->identifierQuoter->quoteIdentifier($metadata->tableName) . " as " . $this->identifierQuoter->quoteIdentifier($rangeName);
+					$tableNames[] = $this->quoteAsAlias($this->identifierQuoter->quoteIdentifier($metadata->tableName), $rangeName);
 				}
 			}
 			
@@ -441,12 +469,12 @@
 				// Regular ranges reference a physical table looked up from the entity store.
 				if ($range instanceof AstRangeDatabaseMaterialized) {
 					$subSQL = $this->convertToSQL($range->getQuery(), $rangeName);
-					$result[] = "{$joinType} JOIN ({$subSQL}) as " . $this->identifierQuoter->quoteIdentifier($rangeName) . " ON {$joinColumn}";
+					$result[] = $this->buildJoinClause($joinType, "({$subSQL})", $rangeName, $joinColumn);
 				} elseif ($range instanceof AstRangeDatabaseTempTable) {
-					$result[] = "{$joinType} JOIN " . $this->identifierQuoter->quoteIdentifier($range->getTableName()) . " as " . $this->identifierQuoter->quoteIdentifier($rangeName) . " ON {$joinColumn}";
+					$result[] = $this->buildJoinClause($joinType, $this->identifierQuoter->quoteIdentifier($range->getTableName()), $rangeName, $joinColumn);
 				} elseif ($range instanceof AstRangeDatabase) {
 					$metadata = $this->entityStore->getMetadata($range->getEntityName());
-					$result[] = "{$joinType} JOIN " . $this->identifierQuoter->quoteIdentifier($metadata->tableName) . " as " . $this->identifierQuoter->quoteIdentifier($rangeName) . " ON {$joinColumn}";
+					$result[] = $this->buildJoinClause($joinType, $this->identifierQuoter->quoteIdentifier($metadata->tableName), $rangeName, $joinColumn);
 				} else {
 					throw new \LogicException(
 						"Unresolved AstRangeDatabaseSubquery '{$rangeName}' reached QuelToSQL — planner did not complete substitution"

--- a/packages/objectquel/src/ObjectQuel/QuelToSQL.php
+++ b/packages/objectquel/src/ObjectQuel/QuelToSQL.php
@@ -16,15 +16,22 @@
 	use Quellabs\ObjectQuel\Execution\Visitors\DetectPrimaryKeyInClauseException;
 	use Quellabs\ObjectQuel\Capabilities\PlatformCapabilitiesInterface;
 	use Quellabs\ObjectQuel\Capabilities\NullPlatformCapabilities;
-	
+	use Quellabs\ObjectQuel\DatabaseAdapter\SqlIdentifierQuoter;
+
 	class QuelToSQL {
-		
+
 		private EntityStore $entityStore;
 		private PlatformCapabilitiesInterface $platform;
-		
+
+		/**
+		 * Quotes identifiers/aliases for whichever engine $platform describes.
+		 * @var SqlIdentifierQuoter
+		 */
+		private SqlIdentifierQuoter $identifierQuoter;
+
 		/** @var array<string, mixed> */
 		private array $parameters;
-		
+
 		/**
 		 * QuelToSQL constructor
 		 * @param EntityStore $entityStore
@@ -39,6 +46,7 @@
 			$this->entityStore = $entityStore;
 			$this->parameters = &$parameters;
 			$this->platform = $platform;
+			$this->identifierQuoter = new SqlIdentifierQuoter($platform);
 		}
 		
 		/**
@@ -117,8 +125,10 @@
 							$aliasName = $outerRangeName . '.' . $aliasName;
 						}
 						
-						// Add the alias to the SQL result
-						$sqlResult .= " as `{$aliasName}`";
+						// Add the alias to the SQL result. $aliasName may itself contain a
+						// literal '.' (see outerRangeName handling above); quoteIdentifier()
+						// never splits on '.', so it survives quoting as a single token.
+						$sqlResult .= " as " . $this->identifierQuoter->quoteIdentifier($aliasName);
 					}
 					
 					// Add the SQL result to the result array
@@ -174,13 +184,13 @@
 				// Regular ranges reference a physical table looked up from the entity store.
 				if ($range instanceof AstRangeDatabaseSubquery) {
 					$subSQL = $this->convertToSQL($range->getQuery(), $rangeName);
-					$tableNames[] = "({$subSQL}) as `{$rangeName}`";
+					$tableNames[] = "({$subSQL}) as " . $this->identifierQuoter->quoteIdentifier($rangeName);
 				} else {
 					// Get the metadata for the entity.
 					$metadata = $this->entityStore->getMetadata($range->getEntityName());
-					
+
 					// Add the table name and alias to the list for the FROM clause.
-					$tableNames[] = "`{$metadata->tableName}` as `{$rangeName}`";
+					$tableNames[] = $this->identifierQuoter->quoteIdentifier($metadata->tableName) . " as " . $this->identifierQuoter->quoteIdentifier($rangeName);
 				}
 			}
 			
@@ -431,12 +441,12 @@
 				// Regular ranges reference a physical table looked up from the entity store.
 				if ($range instanceof AstRangeDatabaseMaterialized) {
 					$subSQL = $this->convertToSQL($range->getQuery(), $rangeName);
-					$result[] = "{$joinType} JOIN ({$subSQL}) as `{$rangeName}` ON {$joinColumn}";
+					$result[] = "{$joinType} JOIN ({$subSQL}) as " . $this->identifierQuoter->quoteIdentifier($rangeName) . " ON {$joinColumn}";
 				} elseif ($range instanceof AstRangeDatabaseTempTable) {
-					$result[] = "{$joinType} JOIN `{$range->getTableName()}` as `{$rangeName}` ON {$joinColumn}";
+					$result[] = "{$joinType} JOIN " . $this->identifierQuoter->quoteIdentifier($range->getTableName()) . " as " . $this->identifierQuoter->quoteIdentifier($rangeName) . " ON {$joinColumn}";
 				} elseif ($range instanceof AstRangeDatabase) {
 					$metadata = $this->entityStore->getMetadata($range->getEntityName());
-					$result[] = "{$joinType} JOIN `{$metadata->tableName}` as `{$rangeName}` ON {$joinColumn}";
+					$result[] = "{$joinType} JOIN " . $this->identifierQuoter->quoteIdentifier($metadata->tableName) . " as " . $this->identifierQuoter->quoteIdentifier($rangeName) . " ON {$joinColumn}";
 				} else {
 					throw new \LogicException(
 						"Unresolved AstRangeDatabaseSubquery '{$rangeName}' reached QuelToSQL — planner did not complete substitution"

--- a/packages/objectquel/src/ObjectQuel/SemanticAnalyzer.php
+++ b/packages/objectquel/src/ObjectQuel/SemanticAnalyzer.php
@@ -8,6 +8,7 @@
 	use Quellabs\ObjectQuel\Exception\SemanticException;
 	use Quellabs\ObjectQuel\Capabilities\NullPlatformCapabilities;
 	use Quellabs\ObjectQuel\Capabilities\PlatformCapabilitiesInterface;
+	use Quellabs\ObjectQuel\DatabaseAdapter\CastTypeMapper;
 	use Quellabs\ObjectQuel\ObjectQuel\Ast\AstCast;
 	use Quellabs\ObjectQuel\ObjectQuel\Ast\AstAggregate;
 	use Quellabs\ObjectQuel\ObjectQuel\Ast\AstIdentifier;
@@ -42,12 +43,11 @@
 		private EntityStore $entityStore;
 		
 		/**
-		 * Platform capabilities used to validate cast types against
-		 * engine-specific supported sets.
-		 * @var PlatformCapabilitiesInterface
+		 * Resolves cast types against engine-specific supported sets.
+		 * @var CastTypeMapper
 		 */
-		private PlatformCapabilitiesInterface $platform;
-		
+		private CastTypeMapper $castTypeMapper;
+
 		/**
 		 * Constructor - initializes the validator with entity schema information
 		 * @param EntityStore $entityStore The entity store containing schema definitions
@@ -55,7 +55,7 @@
 		 */
 		public function __construct(EntityStore $entityStore, PlatformCapabilitiesInterface $platform = new NullPlatformCapabilities()) {
 			$this->entityStore = $entityStore;
-			$this->platform = $platform;
+			$this->castTypeMapper = new CastTypeMapper($platform);
 		}
 		
 		/**
@@ -960,16 +960,16 @@
 		 * the connected database engine supports.
 		 *
 		 * The set of valid types is engine-specific and is retrieved from
-		 * PlatformCapabilitiesInterface::getSupportedCastTypes(). An unsupported
-		 * type name (e.g. (blob)x.data on MySQL) is rejected here with a clear
-		 * message listing the valid alternatives.
+		 * CastTypeMapper::getSupportedCastTypes(). An unsupported type name
+		 * (e.g. (blob)x.data on MySQL) is rejected here with a clear message
+		 * listing the valid alternatives.
 		 *
 		 * @param AstRetrieve $ast
 		 * @throws SemanticException
 		 */
 		private function validateCastTypes(AstRetrieve $ast): void {
 			// Fetch all cast types the database supports
-			$supportedTypes = $this->platform->getSupportedCastTypes();
+			$supportedTypes = $this->castTypeMapper->getSupportedCastTypes();
 			
 			// Collect every AstCast node in the entire query tree
 			$collector = new CollectNodes(AstCast::class);

--- a/packages/objectquel/src/PrimaryKeys/Generators/SequenceGenerator.php
+++ b/packages/objectquel/src/PrimaryKeys/Generators/SequenceGenerator.php
@@ -34,18 +34,25 @@
 			
 			// Get the actual database column name for the primary key
 			$primaryKey = $columnMap[$identifierKeys[0]];
-			
+
+			// Quote identifiers for the connected engine — both are plain real
+			// column/table names, so DatabaseAdapter::escapeIdentifier() (the same
+			// mechanism the Persistence\* classes use for INSERT/UPDATE/DELETE) is
+			// the right tool here.
+			$quotedPrimaryKey = $connection->escapeIdentifier($primaryKey);
+			$quotedTableName = $connection->escapeIdentifier($metadata->tableName);
+
 			// Execute a SQL query to get the next sequence value
 			// This query finds the maximum current value and adds 1
 			$rs = $connection->execute("
 				 SELECT
-					COALESCE(MAX(`{$primaryKey}`), 0) + 1
-				 FROM `{$metadata->tableName}`
+					COALESCE(MAX({$quotedPrimaryKey}), 0) + 1
+				 FROM {$quotedTableName}
 			  ");
-			
+
 			// execute() returns StatementInterface|null
 			if ($rs === null) {
-				throw new \RuntimeException("SequenceGenerator could not generate a sequence for table `{$metadata->tableName}`.");
+				throw new \RuntimeException("SequenceGenerator could not generate a sequence for table '{$metadata->tableName}'.");
 			}
 			
 			// Fetch the single scalar result and return it

--- a/tests/ObjectQuel/Integration/TempTableExecutorTest.php
+++ b/tests/ObjectQuel/Integration/TempTableExecutorTest.php
@@ -57,7 +57,8 @@
 		protected function setUp(): void {
 			$this->executor = new TempTableExecutor(
 				self::em()->getConnection(),
-				self::em()->getEntityStore()
+				self::em()->getEntityStore(),
+				self::em()->getUnitOfWork()->getPlatformCapabilities()
 			);
 		}
 

--- a/versioning/versions.json
+++ b/versioning/versions.json
@@ -37,7 +37,7 @@
   "contracts": "1.2.4",
   "dependency-injection": "1.2.5",
   "discover": "1.1.0",
-  "objectquel": "2.8.4",
+  "objectquel": "2.8.5",
   "recommender": "1.0.0",
   "sculpt": "1.0.31",
   "signal-hub": "1.1.1",


### PR DESCRIPTION
## Summary
- `TempTableExecutor` and `QuelToSQL`'s core FROM/JOIN/alias generation hardcoded MySQL-only backtick quoting and DDL syntax, despite `PlatformCapabilities` already claiming `mysql`/`mariadb`/`pgsql`/`sqlite`/`sqlsrv` support
- Added `DDLTypeMapper` (temp-table DDL: CREATE/DROP keywords, SQL Server's `#`-prefixed physical name, per-engine column types) and `SqlIdentifierQuoter` (general identifier/alias quoting), both driven by `PlatformCapabilitiesInterface`
- Extracted `CastTypeMapper` for QUEL `CAST(...)` type tokens and fixed SQL Server's `CAST(x AS SIGNED)`/`CAST(x AS DOUBLE)` — both invalid T-SQL, silently inherited from the MySQL `default` branch
- Finished the identifier-quoting migration into `ProcessExpression`, `BuildSqlFragments`, `ProcessAggregate`, and `SequenceGenerator`, which a code review of this branch found still hardcoded backticks after the initial pass
- Fixed a SQLite double-quote correctness bug (an unresolvable double-quoted identifier silently becomes a string literal on SQLite instead of erroring) and a missing `sqlsrv` branch in JSON path extraction (was falling through to MySQL-only `JSON_UNQUOTE`/`JSON_EXTRACT`)

## Test plan
- [x] PHPStan level 9 clean project-wide
- [x] Full test suite passes (1075 tests, 1681 assertions)
- [ ] Not yet verified against a live PostgreSQL, SQLite, or SQL Server instance — this repo's only DB-backed integration test coverage is MySQL

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V8cmiBK1fiVF8HNdkj49ev