### PR TITLE
Eager-join a bridge's own relations when queried directly, fix self-referencing exclusion

### DIFF
--- a/packages/objectquel/src/Execution/QueryBuilder.php
+++ b/packages/objectquel/src/Execution/QueryBuilder.php
@@ -156,7 +156,11 @@
 
 				// If this dependent is itself marked @Orm\EntityBridge, eager-join one hop
 				// further through its own relations instead of leaving the far side lazy.
-				$this->addBridgeExpansionRanges($dependentEntityType, $alias, $entityType, $ranges, $rangeCounter);
+				// Exclude by $property (the exact relation just used to reach the bridge),
+				// not by target type — a self-referencing bridge (e.g. Friendship::$userA
+				// and $userB both targeting User) would otherwise have both relations
+				// excluded just for sharing a target type with the one that reached it.
+				$this->addBridgeExpansionRanges($dependentEntityType, $alias, null, $property, $ranges, $rangeCounter);
 			}
 		}
 
@@ -166,16 +170,28 @@
 		 * relations — eager-join one hop further through its own relations, so the far side of
 		 * the link resolves in the same query rather than lazily per row.
 		 *
-		 * The relation that was just used to reach the bridge from $excludedEntityType is
-		 * skipped, so the entity already being loaded doesn't get rejoined. Pass null when
-		 * there is no such relation — e.g. the bridge itself is 'main' because the caller
-		 * queried it directly, so nothing has been reached via it yet. The via-clause is
-		 * anchored on the bridge's own alias, which is 'main' in that direct-query case and
-		 * a joined alias otherwise (e.g. "range of r1 is Tag via r0.tag") — not
-		 * self-referential, since the bridge range and the target range differ.
+		 * Two independent, mutually-exclusive exclusion criteria prevent rejoining the
+		 * entity already reached via this bridge — each caller uses whichever one it can
+		 * actually identify:
+		 *  - $excludedProperty matches by relation identity: the exact property on the
+		 *    bridge itself that was just used to reach it (the child-side case, where that
+		 *    property is known). Matching by identity rather than target type means a
+		 *    self-referencing bridge (e.g. Friendship::$userA and $userB both targeting
+		 *    User) still gets its other relation joined instead of losing both to a
+		 *    type-based match.
+		 *  - $excludedEntityType matches by target type: used when the bridge was reached
+		 *    via a relation that lives on the *other* side (the forward case, where main
+		 *    owns the relation into the bridge, not the reverse) — there is no bridge-owned
+		 *    property to match by identity there, only "don't rejoin main's own type".
+		 * Pass both as null when there is nothing to exclude — e.g. the bridge itself is
+		 * 'main' because the caller queried it directly, so nothing has been reached via it
+		 * yet. The via-clause is anchored on the bridge's own alias, which is 'main' in that
+		 * direct-query case and a joined alias otherwise (e.g. "range of r1 is Tag via
+		 * r0.tag") — not self-referential, since the bridge range and the target range differ.
 		 * @param string $bridgeEntityType The bridge entity's class name
 		 * @param string $bridgeAlias The alias the bridge's own range was assigned ('main' when the bridge is the queried entity itself)
-		 * @param string|null $excludedEntityType The entity type already reached via this bridge, or null if none
+		 * @param string|null $excludedEntityType Target type to skip (forward case), or null
+		 * @param string|null $excludedProperty Bridge-owned property to skip by identity (child-side case), or null
 		 * @param array<string, string> $ranges Accumulator array (modified in place)
 		 * @param int $rangeCounter Alias counter (modified in place)
 		 * @return void
@@ -185,6 +201,7 @@
 			string $bridgeEntityType,
 			string $bridgeAlias,
 			?string $excludedEntityType,
+			?string $excludedProperty,
 			array &$ranges,
 			int &$rangeCounter
 		): void {
@@ -203,10 +220,19 @@
 					continue;
 				}
 
+				// Skip the exact relation that was just used to reach the bridge, by
+				// property identity — see the method docblock for why this is preferred
+				// over a target-type match wherever the property is known.
+				if ($excludedProperty !== null && $property === $excludedProperty) {
+					continue;
+				}
+
 				$targetEntityType = $this->entityStore->normalizeEntityClass($relation->getTargetEntity());
 
-				// Skip the relation that was just used to reach the bridge — re-adding it
-				// would rejoin the entity already being loaded back into the query.
+				// Skip any bridge relation whose target is the entity type that reached
+				// the bridge via its own (non-bridge-owned) relation — that entity is
+				// already 'main'. Only used when there's no bridge-owned property to
+				// match by identity instead (see docblock).
 				if ($excludedEntityType !== null && $targetEntityType === $excludedEntityType) {
 					continue;
 				}
@@ -267,7 +293,7 @@
 			// gets when reached as a dependent or via a forward relation, just anchored on
 			// 'main' since a direct query means nothing has reached it to exclude.
 			if ($this->entityStore->getMetadata($entityType)->isEntityBridge()) {
-				$this->addBridgeExpansionRanges($entityType, 'main', null, $ranges, $rangeCounter);
+				$this->addBridgeExpansionRanges($entityType, 'main', null, null, $ranges, $rangeCounter);
 			}
 
 			// getDependentEntities returns every entity type that declares a relationship
@@ -343,8 +369,10 @@
 				$ranges[$alias] = "range of {$alias} is {$targetEntityType} via main.{$property}";
 
 				// Extend one hop further through the bridge's own relations, excluding
-				// $entityType so a relation pointing back at it (if any) isn't rejoined.
-				$this->addBridgeExpansionRanges($targetEntityType, $alias, $entityType, $ranges, $rangeCounter);
+				// $entityType by target type (no bridge-owned property identifies this
+				// relation — it lives on $entityType's side, not the bridge's) so a
+				// relation pointing back at it (if any) isn't rejoined.
+				$this->addBridgeExpansionRanges($targetEntityType, $alias, $entityType, null, $ranges, $rangeCounter);
 			}
 		}
 		

--- a/packages/objectquel/src/Execution/QueryBuilder.php
+++ b/packages/objectquel/src/Execution/QueryBuilder.php
@@ -167,12 +167,15 @@
 		 * the link resolves in the same query rather than lazily per row.
 		 *
 		 * The relation that was just used to reach the bridge from $excludedEntityType is
-		 * skipped, so the entity already being loaded doesn't get rejoined. The via-clause is
-		 * anchored on the bridge's own alias rather than 'main' (e.g. "range of r1 is Tag via
-		 * r0.tag") — not self-referential, since the bridge range and the target range differ.
+		 * skipped, so the entity already being loaded doesn't get rejoined. Pass null when
+		 * there is no such relation — e.g. the bridge itself is 'main' because the caller
+		 * queried it directly, so nothing has been reached via it yet. The via-clause is
+		 * anchored on the bridge's own alias, which is 'main' in that direct-query case and
+		 * a joined alias otherwise (e.g. "range of r1 is Tag via r0.tag") — not
+		 * self-referential, since the bridge range and the target range differ.
 		 * @param string $bridgeEntityType The bridge entity's class name
-		 * @param string $bridgeAlias The alias addRanges() just assigned to the bridge's own range
-		 * @param string $excludedEntityType The entity type already reached via this bridge
+		 * @param string $bridgeAlias The alias the bridge's own range was assigned ('main' when the bridge is the queried entity itself)
+		 * @param string|null $excludedEntityType The entity type already reached via this bridge, or null if none
 		 * @param array<string, string> $ranges Accumulator array (modified in place)
 		 * @param int $rangeCounter Alias counter (modified in place)
 		 * @return void
@@ -181,7 +184,7 @@
 		private function addBridgeExpansionRanges(
 			string $bridgeEntityType,
 			string $bridgeAlias,
-			string $excludedEntityType,
+			?string $excludedEntityType,
 			array &$ranges,
 			int &$rangeCounter
 		): void {
@@ -204,7 +207,7 @@
 
 				// Skip the relation that was just used to reach the bridge — re-adding it
 				// would rejoin the entity already being loaded back into the query.
-				if ($targetEntityType === $excludedEntityType) {
+				if ($excludedEntityType !== null && $targetEntityType === $excludedEntityType) {
 					continue;
 				}
 
@@ -245,7 +248,9 @@
 		 *
 		 * The first entry is always 'main'. Subsequent entries are derived from OneToOne
 		 * (owned-side only) and ManyToOne relationships on each entity that declares a
-		 * dependency on $entityType.
+		 * dependency on $entityType, plus — when $entityType is itself an @Orm\EntityBridge —
+		 * its own two relations, and — when $entityType owns a relation into a bridge — that
+		 * bridge and one hop past it.
 		 *
 		 * @param string $entityType The entity type for which relationships should be retrieved.
 		 * @return array<string, string> Range definitions keyed by alias.
@@ -256,7 +261,15 @@
 			// All other ranges are joins relative to it.
 			$ranges = ['main' => "range of main is {$entityType}"];
 			$rangeCounter = 0;
-			
+
+			// If the queried entity is itself an @Orm\EntityBridge, eager-join its own two
+			// relations directly off 'main' (subject to fetch) — the same expansion a bridge
+			// gets when reached as a dependent or via a forward relation, just anchored on
+			// 'main' since a direct query means nothing has reached it to exclude.
+			if ($this->entityStore->getMetadata($entityType)->isEntityBridge()) {
+				$this->addBridgeExpansionRanges($entityType, 'main', null, $ranges, $rangeCounter);
+			}
+
 			// getDependentEntities returns every entity type that declares a relationship
 			// pointing at $entityType. We inspect each one for eagerly-fetchable relations
 			// and add a range for each qualifying join.

--- a/tests/ObjectQuel/Fixtures/RelationshipEntities/RelFriendUserEntity.php
+++ b/tests/ObjectQuel/Fixtures/RelationshipEntities/RelFriendUserEntity.php
@@ -1,0 +1,39 @@
+<?php
+
+	namespace Quellabs\ObjectQuel\Tests\Fixtures\RelationshipEntities;
+
+	use Quellabs\ObjectQuel\Annotations\Orm\Table;
+	use Quellabs\ObjectQuel\Annotations\Orm\Column;
+	use Quellabs\ObjectQuel\Annotations\Orm\PrimaryKeyStrategy;
+	use Quellabs\ObjectQuel\Annotations\Orm\InverseOf;
+	use Quellabs\ObjectQuel\Collections\Collection;
+	use Quellabs\ObjectQuel\Collections\CollectionInterface;
+
+	/**
+	 * The "self" side of a self-referencing bridge: RelFriendshipEntity links two
+	 * RelFriendUserEntity rows via its own $userA/$userB ManyToOne relations, both
+	 * targeting this same entity type. Reaching the bridge from here (via $userA)
+	 * exercises the case where target-type-based exclusion would wrongly also skip
+	 * $userB, since both relations share this type.
+	 * @Orm\Table(name="rel_friend_users")
+	 */
+	class RelFriendUserEntity {
+		/**
+		 * @Orm\Column(name="id", type="integer", unsigned=true, primary_key=true)
+		 * @Orm\PrimaryKeyStrategy(strategy="identity")
+		 */
+		protected ?int $id = null;
+
+		/**
+		 * @Orm\InverseOf(targetEntity=RelFriendshipEntity::class, relation="userA")
+		 */
+		public CollectionInterface $friendshipsAsA;
+
+		public function __construct() {
+			$this->friendshipsAsA = new Collection();
+		}
+
+		public function getId(): ?int {
+			return $this->id;
+		}
+	}

--- a/tests/ObjectQuel/Fixtures/RelationshipEntities/RelFriendshipEntity.php
+++ b/tests/ObjectQuel/Fixtures/RelationshipEntities/RelFriendshipEntity.php
@@ -1,0 +1,50 @@
+<?php
+
+	namespace Quellabs\ObjectQuel\Tests\Fixtures\RelationshipEntities;
+
+	use Quellabs\ObjectQuel\Annotations\Orm\Table;
+	use Quellabs\ObjectQuel\Annotations\Orm\Column;
+	use Quellabs\ObjectQuel\Annotations\Orm\PrimaryKeyStrategy;
+	use Quellabs\ObjectQuel\Annotations\Orm\ManyToOne;
+	use Quellabs\ObjectQuel\Annotations\Orm\EntityBridge;
+
+	/**
+	 * A self-referencing bridge: both $userA and $userB target RelFriendUserEntity —
+	 * the same entity type on both sides of the link. Exists to prove
+	 * QueryBuilder::addBridgeExpansionRanges() excludes the reaching relation by
+	 * property identity, not by target type; a type-based exclusion would incorrectly
+	 * skip both relations here since they share a target type.
+	 * @Orm\Table(name="rel_friendships")
+	 * @Orm\EntityBridge
+	 */
+	class RelFriendshipEntity {
+		/**
+		 * @Orm\Column(name="id", type="integer", unsigned=true, primary_key=true)
+		 * @Orm\PrimaryKeyStrategy(strategy="identity")
+		 */
+		protected ?int $id = null;
+
+		/**
+		 * @Orm\ManyToOne(targetEntity=RelFriendUserEntity::class, localColumn="userAId", fetch="EAGER")
+		 */
+		public ?RelFriendUserEntity $userA = null;
+
+		/**
+		 * @Orm\Column(name="user_a_id", type="integer")
+		 */
+		protected ?int $userAId = null;
+
+		/**
+		 * @Orm\ManyToOne(targetEntity=RelFriendUserEntity::class, localColumn="userBId", fetch="EAGER")
+		 */
+		public ?RelFriendUserEntity $userB = null;
+
+		/**
+		 * @Orm\Column(name="user_b_id", type="integer")
+		 */
+		protected ?int $userBId = null;
+
+		public function getId(): ?int {
+			return $this->id;
+		}
+	}

--- a/tests/ObjectQuel/Integration/EntityBridgeDirectQueryEagerLoadTest.php
+++ b/tests/ObjectQuel/Integration/EntityBridgeDirectQueryEagerLoadTest.php
@@ -1,0 +1,120 @@
+<?php
+
+	namespace Quellabs\ObjectQuel\Tests\Integration;
+
+	use PHPUnit\Framework\TestCase;
+	use Quellabs\ObjectQuel\Execution\QueryBuilder;
+	use Quellabs\ObjectQuel\ProxyGenerator\ProxyInterface;
+	use Quellabs\ObjectQuel\Tests\Fixtures\RelationshipEntities\RelCategoryEntity;
+	use Quellabs\ObjectQuel\Tests\Fixtures\RelationshipEntities\RelPostEntity;
+	use Quellabs\ObjectQuel\Tests\Fixtures\RelationshipEntities\RelPostTagEntity;
+	use Quellabs\ObjectQuel\Tests\Fixtures\RelationshipEntities\RelTagEntity;
+
+	/**
+	 * Validates a third @Orm\EntityBridge case, distinct from both the child-side
+	 * (EntityBridgeEagerLoadTest) and forward (EntityBridgeForwardEagerLoadTest) ones:
+	 * querying the bridge entity itself directly. RelPostTagEntity::$post/$tag must
+	 * still be eager-joined off 'main' (subject to fetch) even though nothing reached
+	 * the bridge via another entity's relation — there is no relation to exclude,
+	 * since the bridge itself is 'main'.
+	 *
+	 * Uses the suite's shared $GLOBALS['test_em'] (SignalHub allows only one
+	 * EntityManager per process) and its own tables, created idempotently in
+	 * setUp() since another test class may have claimed the connection first.
+	 */
+	class EntityBridgeDirectQueryEagerLoadTest extends TestCase {
+
+		protected function setUp(): void {
+			$em = $GLOBALS['test_em'];
+			$adapter = $em->getConnection();
+
+			$adapter->execute('CREATE TABLE IF NOT EXISTS rel_posts (id INT UNSIGNED AUTO_INCREMENT PRIMARY KEY) ENGINE=InnoDB');
+			$adapter->execute('CREATE TABLE IF NOT EXISTS rel_tags (id INT UNSIGNED AUTO_INCREMENT PRIMARY KEY) ENGINE=InnoDB');
+			$adapter->execute('CREATE TABLE IF NOT EXISTS rel_categories (id INT UNSIGNED AUTO_INCREMENT PRIMARY KEY) ENGINE=InnoDB');
+			$adapter->execute('CREATE TABLE IF NOT EXISTS rel_post_tags (id INT UNSIGNED AUTO_INCREMENT PRIMARY KEY, post_id INT, tag_id INT, category_id INT) ENGINE=InnoDB');
+
+			foreach (['rel_post_tags', 'rel_posts', 'rel_tags', 'rel_categories'] as $table) {
+				$adapter->execute("DELETE FROM {$table}");
+			}
+
+			$em->getUnitOfWork()->clear();
+		}
+
+		/**
+		 * Direct evidence of the query shape: querying the bridge itself must emit
+		 * ranges for both of its own EAGER relations, anchored on 'main' rather than
+		 * a joined alias, since the bridge itself is what was queried.
+		 */
+		public function testQueryBuilderEagerJoinsABridgesOwnRelationsWhenQueriedDirectly(): void {
+			$entityStore = $GLOBALS['test_em']->getEntityStore();
+			$queryBuilder = new QueryBuilder($entityStore);
+
+			$query = $queryBuilder->prepareQuery(RelPostTagEntity::class, ['id' => 1]);
+
+			self::assertMatchesRegularExpression(
+				'/range of \w+ is ' . preg_quote(RelPostEntity::class, '/') . ' via main\.post/',
+				$query,
+				$query
+			);
+
+			self::assertMatchesRegularExpression(
+				'/range of \w+ is ' . preg_quote(RelTagEntity::class, '/') . ' via main\.tag/',
+				$query,
+				$query
+			);
+		}
+
+		/**
+		 * End-to-end: fetching a RelPostTagEntity directly must come back with both
+		 * $post and $tag already hydrated, not lazy proxies needing a further query.
+		 */
+		public function testFindEagerlyHydratesABridgesOwnRelationsWhenQueriedDirectly(): void {
+			$em = $GLOBALS['test_em'];
+
+			$post = new RelPostEntity();
+			$em->persist($post);
+			$em->flush();
+
+			$tag = new RelTagEntity();
+			$em->persist($tag);
+			$em->flush();
+
+			$postTag = new RelPostTagEntity();
+			$postTag->post = $post;
+			$postTag->tag = $tag;
+			$em->persist($postTag);
+			$em->flush();
+
+			$em->getUnitOfWork()->clear();
+
+			/** @var RelPostTagEntity $loadedPostTag */
+			$loadedPostTag = $em->find(RelPostTagEntity::class, $postTag->getId());
+
+			self::assertNotNull($loadedPostTag);
+
+			self::assertFalse(
+				$loadedPostTag->post instanceof ProxyInterface,
+				'Expected the bridge\'s own $post relation to be eagerly hydrated when queried directly.'
+			);
+			self::assertSame($post->getId(), $loadedPostTag->post->getId());
+
+			self::assertFalse(
+				$loadedPostTag->tag instanceof ProxyInterface,
+				'Expected the bridge\'s own $tag relation to be eagerly hydrated when queried directly.'
+			);
+			self::assertSame($tag->getId(), $loadedPostTag->tag->getId());
+		}
+
+		/**
+		 * Control: RelPostTagEntity::$category is LAZY, so it must not get eager-joined
+		 * even when the bridge itself is the entity being queried directly.
+		 */
+		public function testLazyRelationOnADirectlyQueriedBridgeGetsNoEagerJoin(): void {
+			$entityStore = $GLOBALS['test_em']->getEntityStore();
+			$queryBuilder = new QueryBuilder($entityStore);
+
+			$query = $queryBuilder->prepareQuery(RelPostTagEntity::class, ['id' => 1]);
+
+			self::assertStringNotContainsString(RelCategoryEntity::class, $query, $query);
+		}
+	}

--- a/tests/ObjectQuel/Integration/EntityBridgeSelfReferencingEagerLoadTest.php
+++ b/tests/ObjectQuel/Integration/EntityBridgeSelfReferencingEagerLoadTest.php
@@ -1,0 +1,101 @@
+<?php
+
+	namespace Quellabs\ObjectQuel\Tests\Integration;
+
+	use PHPUnit\Framework\TestCase;
+	use Quellabs\ObjectQuel\Execution\QueryBuilder;
+	use Quellabs\ObjectQuel\ProxyGenerator\ProxyInterface;
+	use Quellabs\ObjectQuel\Tests\Fixtures\RelationshipEntities\RelFriendshipEntity;
+	use Quellabs\ObjectQuel\Tests\Fixtures\RelationshipEntities\RelFriendUserEntity;
+
+	/**
+	 * Validates that addBridgeExpansionRanges() excludes the relation that reached a
+	 * bridge by property identity, not by target entity type. RelFriendshipEntity is a
+	 * self-referencing bridge: both $userA and $userB target RelFriendUserEntity, so a
+	 * type-based exclusion would incorrectly drop both relations when the bridge is
+	 * reached via $userA (their shared target type would match the exclusion for
+	 * either one) — before this fix, $userB never got its extra hop at all.
+	 *
+	 * Uses the suite's shared $GLOBALS['test_em'] (SignalHub allows only one
+	 * EntityManager per process) and its own tables, created idempotently in
+	 * setUp() since another test class may have claimed the connection first.
+	 */
+	class EntityBridgeSelfReferencingEagerLoadTest extends TestCase {
+
+		protected function setUp(): void {
+			$em = $GLOBALS['test_em'];
+			$adapter = $em->getConnection();
+
+			$adapter->execute('CREATE TABLE IF NOT EXISTS rel_friend_users (id INT UNSIGNED AUTO_INCREMENT PRIMARY KEY) ENGINE=InnoDB');
+			$adapter->execute('CREATE TABLE IF NOT EXISTS rel_friendships (id INT UNSIGNED AUTO_INCREMENT PRIMARY KEY, user_a_id INT, user_b_id INT) ENGINE=InnoDB');
+
+			foreach (['rel_friendships', 'rel_friend_users'] as $table) {
+				$adapter->execute("DELETE FROM {$table}");
+			}
+
+			$em->getUnitOfWork()->clear();
+		}
+
+		/**
+		 * Direct evidence of the query shape: querying the "self" side of a
+		 * self-referencing bridge must still emit a far-side hop for $userB, even
+		 * though $userB shares a target type with $userA (the relation that reached
+		 * the bridge).
+		 */
+		public function testQueryBuilderStillJoinsTheFarSideOfASelfReferencingBridge(): void {
+			$entityStore = $GLOBALS['test_em']->getEntityStore();
+			$queryBuilder = new QueryBuilder($entityStore);
+
+			$query = $queryBuilder->prepareQuery(RelFriendUserEntity::class, ['id' => 1]);
+
+			$hop1Pattern = '/range of (\w+) is ' . preg_quote(RelFriendshipEntity::class, '/') . ' via main\.friendshipsAsA/';
+			self::assertMatchesRegularExpression($hop1Pattern, $query, $query);
+
+			preg_match($hop1Pattern, $query, $matches);
+			$bridgeAlias = $matches[1];
+
+			// The far side ($userB) must still be joined off the bridge's own alias,
+			// not silently dropped for sharing RelFriendUserEntity as its target type.
+			$hop2Pattern = '/range of \w+ is ' . preg_quote(RelFriendUserEntity::class, '/') . ' via ' . preg_quote($bridgeAlias, '/') . '\.userB/';
+			self::assertMatchesRegularExpression($hop2Pattern, $query, $query);
+		}
+
+		/**
+		 * End-to-end: fetching a RelFriendUserEntity must come back with $userB
+		 * already hydrated off the bridge, not a lazy proxy.
+		 */
+		public function testFindEagerlyHydratesTheFarSideOfASelfReferencingBridge(): void {
+			$em = $GLOBALS['test_em'];
+
+			$userA = new RelFriendUserEntity();
+			$em->persist($userA);
+			$em->flush();
+
+			$userB = new RelFriendUserEntity();
+			$em->persist($userB);
+			$em->flush();
+
+			$friendship = new RelFriendshipEntity();
+			$friendship->userA = $userA;
+			$friendship->userB = $userB;
+			$em->persist($friendship);
+			$em->flush();
+
+			$em->getUnitOfWork()->clear();
+
+			/** @var RelFriendUserEntity $loadedUserA */
+			$loadedUserA = $em->find(RelFriendUserEntity::class, $userA->getId());
+
+			self::assertNotNull($loadedUserA);
+			self::assertCount(1, $loadedUserA->friendshipsAsA);
+
+			$loadedUserB = $loadedUserA->friendshipsAsA->first()->userB;
+
+			self::assertInstanceOf(RelFriendUserEntity::class, $loadedUserB);
+			self::assertFalse(
+				$loadedUserB instanceof ProxyInterface,
+				'Expected the far side of a self-referencing bridge to be eagerly hydrated, not a lazy proxy.'
+			);
+			self::assertSame($userB->getId(), $loadedUserB->getId());
+		}
+	}

--- a/versioning/versions.json
+++ b/versioning/versions.json
@@ -37,7 +37,7 @@
   "contracts": "1.2.4",
   "dependency-injection": "1.2.5",
   "discover": "1.1.0",
-  "objectquel": "2.9.0",
+  "objectquel": "2.9.1",
   "recommender": "1.0.0",
   "sculpt": "1.0.31",
   "signal-hub": "1.1.1",


### PR DESCRIPTION
## Summary
Two follow-up fixes to the `@Orm\EntityBridge` eager-loading work merged in #341:

- **Direct bridge query** (`b6690da9`): querying a bridge entity itself directly (e.g. `find(PostTagEntity::class, $id)`) previously always lazy-loaded its own `ManyToOne`/`OneToOne` relations, regardless of `fetch`, since neither the child-side walk nor the forward-relation walk covers the bridge itself being `main`. `addBridgeExpansionRanges()`'s `$excludedEntityType` is now nullable so `getRelationRanges()` can call it with `bridgeAlias='main'` and no exclusion in this case, reusing the same expansion logic as the other two cases.
- **Self-referencing bridge exclusion bug** (`10a75e76`): `addBridgeExpansionRanges()` excluded the relation that reached a bridge by matching *target entity type*. For a bridge whose two relations target the same entity type (e.g. `Friendship::$userA`/`$userB` both → `User`), that incorrectly excluded both relations instead of just the one used to reach it, so the far side never got its extra hop even with `fetch="EAGER"`. Split the exclusion into two independent parameters — `$excludedProperty` (relation identity, used by the child-side call site which knows the exact reaching property) and `$excludedEntityType` (target-type match, kept for the forward call site which has no bridge-owned property to match against).

Version bump: `objectquel` 2.9.0 → 2.9.1 (patch — bug fixes on top of the 2.9.0 feature).

## Test plan
- [x] New `tests/ObjectQuel/Integration/EntityBridgeDirectQueryEagerLoadTest.php`: query-shape test, end-to-end hydration test, `LAZY`-skip control test.
- [x] New `tests/ObjectQuel/Integration/EntityBridgeSelfReferencingEagerLoadTest.php` + fixtures (`RelFriendUserEntity`/`RelFriendshipEntity`, a self-referencing bridge): query-shape test proving the far side (`$userB`) still joins, end-to-end hydration test.
- [x] Full `tests/ObjectQuel` suite and PHPStan run clean (confirmed manually).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019B8HChRPzLGhJsc8g6stFu